### PR TITLE
Bugfix/gh28/link special chars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-site-generator",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,7 +16,7 @@
       "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "*"
+        "@types/babel-types": "7.0.2"
       }
     },
     "@types/configstore": {
@@ -50,9 +50,9 @@
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
+        "@types/events": "1.2.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "7.0.64"
       }
     },
     "@types/history": {
@@ -80,7 +80,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.14.tgz",
       "integrity": "sha512-wNUGm49fPl7eE2fnYdF0v5vSOrUMdKMQD/4NwtQRnb6mnPwtkhabmuFz37eq90+hhyfz0pWd38jkZHOcaZ6LGw==",
       "requires": {
-        "csstype": "^2.2.0"
+        "csstype": "2.5.0"
       }
     },
     "@types/react-router": {
@@ -88,8 +88,8 @@
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.0.25.tgz",
       "integrity": "sha512-IsFvDwQy2X08g+tRMvugH1l7e0kkR+o5qEUkFfYLmjw2jGCPogY2bBuRAgZCZ5CSUswdNTkKtPUmNo+f6afyfg==",
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*"
+        "@types/history": "4.6.2",
+        "@types/react": "16.3.14"
       }
     },
     "@types/react-router-dom": {
@@ -97,9 +97,9 @@
       "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-4.2.6.tgz",
       "integrity": "sha512-K7SdbkF8xgecp2WCeXw51IMySYvQ1EuVPKfjU1fymyTSX9bZk5Qx8T5cipwtAY8Zhb/4GIjhYKm0ZGVEbCKEzQ==",
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*",
-        "@types/react-router": "*"
+        "@types/history": "4.6.2",
+        "@types/react": "16.3.14",
+        "@types/react-router": "4.0.25"
       }
     },
     "@types/tmp": {
@@ -114,7 +114,7 @@
       "dev": true,
       "requires": {
         "jsonparse": "0.0.5",
-        "through": ">=2.2.7 <3"
+        "through": "2.3.8"
       }
     },
     "accepts": {
@@ -122,7 +122,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -137,7 +137,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       }
     },
     "address": {
@@ -161,10 +161,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -178,9 +178,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "alphanum-sort": {
@@ -194,7 +194,7 @@
       "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
       "dev": true,
       "requires": {
-        "stable": "~0.1.3"
+        "stable": "0.1.8"
       }
     },
     "amdefine": {
@@ -212,7 +212,7 @@
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       }
     },
     "ansi-escapes": {
@@ -258,8 +258,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "aproba": {
@@ -277,7 +277,7 @@
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
       "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
       "requires": {
-        "file-type": "^3.1.0"
+        "file-type": "3.9.0"
       },
       "dependencies": {
         "file-type": {
@@ -298,8 +298,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "argparse": {
@@ -307,7 +307,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "args": {
@@ -326,7 +326,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "camelcase": {
@@ -339,9 +339,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -354,7 +354,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -366,7 +366,7 @@
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7",
-        "commander": "^2.11.0"
+        "commander": "2.15.1"
       },
       "dependencies": {
         "commander": {
@@ -382,7 +382,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -426,8 +426,8 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.11.0"
       }
     },
     "array-iterate": {
@@ -455,7 +455,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -494,9 +494,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "assert": {
@@ -522,9 +522,9 @@
       "resolved": "https://registry.npmjs.org/ast-transform/-/ast-transform-0.0.0.tgz",
       "integrity": "sha1-dJRAWIh9goPhidlUYAlHvJj+AGI=",
       "requires": {
-        "escodegen": "~1.2.0",
-        "esprima": "~1.0.4",
-        "through": "~2.3.4"
+        "escodegen": "1.2.0",
+        "esprima": "1.0.4",
+        "through": "2.3.8"
       },
       "dependencies": {
         "esprima": {
@@ -556,7 +556,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "4.17.10"
       }
     },
     "async-each": {
@@ -589,12 +589,12 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "requires": {
-        "browserslist": "^1.7.6",
-        "caniuse-db": "^1.0.30000634",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^5.2.16",
-        "postcss-value-parser": "^3.2.3"
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000839",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "browserslist": {
@@ -602,8 +602,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000839",
+            "electron-to-chromium": "1.3.45"
           }
         }
       }
@@ -633,18 +633,18 @@
       "integrity": "sha1-37CHwiiUkXxXb7Z86c8yjUWGKfs=",
       "dev": true,
       "requires": {
-        "babel-core": "^5.6.21",
-        "chokidar": "^1.0.0",
-        "commander": "^2.6.0",
-        "convert-source-map": "^1.1.0",
-        "fs-readdir-recursive": "^0.1.0",
-        "glob": "^5.0.5",
-        "lodash": "^3.2.0",
-        "output-file-sync": "^1.1.0",
-        "path-exists": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.0"
+        "babel-core": "5.8.38",
+        "chokidar": "1.7.0",
+        "commander": "2.9.0",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "0.1.2",
+        "glob": "5.0.15",
+        "lodash": "3.10.1",
+        "output-file-sync": "1.1.2",
+        "path-exists": "1.0.0",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "babel-core": {
@@ -653,52 +653,52 @@
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "dev": true,
           "requires": {
-            "babel-plugin-constant-folding": "^1.0.1",
-            "babel-plugin-dead-code-elimination": "^1.0.2",
-            "babel-plugin-eval": "^1.0.1",
-            "babel-plugin-inline-environment-variables": "^1.0.1",
-            "babel-plugin-jscript": "^1.0.4",
-            "babel-plugin-member-expression-literals": "^1.0.1",
-            "babel-plugin-property-literals": "^1.0.1",
-            "babel-plugin-proto-to-assign": "^1.0.3",
-            "babel-plugin-react-constant-elements": "^1.0.3",
-            "babel-plugin-react-display-name": "^1.0.3",
-            "babel-plugin-remove-console": "^1.0.1",
-            "babel-plugin-remove-debugger": "^1.0.1",
-            "babel-plugin-runtime": "^1.0.7",
-            "babel-plugin-undeclared-variables-check": "^1.0.2",
-            "babel-plugin-undefined-to-void": "^1.1.6",
-            "babylon": "^5.8.38",
-            "bluebird": "^2.9.33",
-            "chalk": "^1.0.0",
-            "convert-source-map": "^1.1.0",
-            "core-js": "^1.0.0",
-            "debug": "^2.1.1",
-            "detect-indent": "^3.0.0",
-            "esutils": "^2.0.0",
-            "fs-readdir-recursive": "^0.1.0",
-            "globals": "^6.4.0",
-            "home-or-tmp": "^1.0.0",
-            "is-integer": "^1.0.4",
+            "babel-plugin-constant-folding": "1.0.1",
+            "babel-plugin-dead-code-elimination": "1.0.2",
+            "babel-plugin-eval": "1.0.1",
+            "babel-plugin-inline-environment-variables": "1.0.1",
+            "babel-plugin-jscript": "1.0.4",
+            "babel-plugin-member-expression-literals": "1.0.1",
+            "babel-plugin-property-literals": "1.0.1",
+            "babel-plugin-proto-to-assign": "1.0.4",
+            "babel-plugin-react-constant-elements": "1.0.3",
+            "babel-plugin-react-display-name": "1.0.3",
+            "babel-plugin-remove-console": "1.0.1",
+            "babel-plugin-remove-debugger": "1.0.1",
+            "babel-plugin-runtime": "1.0.7",
+            "babel-plugin-undeclared-variables-check": "1.0.2",
+            "babel-plugin-undefined-to-void": "1.1.6",
+            "babylon": "5.8.38",
+            "bluebird": "2.11.0",
+            "chalk": "1.1.3",
+            "convert-source-map": "1.5.1",
+            "core-js": "1.2.7",
+            "debug": "2.6.9",
+            "detect-indent": "3.0.1",
+            "esutils": "2.0.2",
+            "fs-readdir-recursive": "0.1.2",
+            "globals": "6.4.1",
+            "home-or-tmp": "1.0.0",
+            "is-integer": "1.0.7",
             "js-tokens": "1.0.1",
-            "json5": "^0.4.0",
-            "lodash": "^3.10.0",
-            "minimatch": "^2.0.3",
-            "output-file-sync": "^1.1.0",
-            "path-exists": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "private": "^0.1.6",
+            "json5": "0.4.0",
+            "lodash": "3.10.1",
+            "minimatch": "2.0.10",
+            "output-file-sync": "1.1.2",
+            "path-exists": "1.0.0",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
             "regenerator": "0.8.40",
-            "regexpu": "^1.3.0",
-            "repeating": "^1.1.2",
-            "resolve": "^1.1.6",
-            "shebang-regex": "^1.0.0",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.0",
-            "source-map-support": "^0.2.10",
-            "to-fast-properties": "^1.0.0",
-            "trim-right": "^1.0.0",
-            "try-resolve": "^1.0.0"
+            "regexpu": "1.3.0",
+            "repeating": "1.1.3",
+            "resolve": "1.7.1",
+            "shebang-regex": "1.0.0",
+            "slash": "1.0.0",
+            "source-map": "0.5.7",
+            "source-map-support": "0.2.10",
+            "to-fast-properties": "1.0.3",
+            "trim-right": "1.0.1",
+            "try-resolve": "1.0.1"
           }
         },
         "babylon": {
@@ -725,9 +725,9 @@
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "minimist": "^1.1.0",
-            "repeating": "^1.1.0"
+            "get-stdin": "4.0.1",
+            "minimist": "1.2.0",
+            "repeating": "1.1.3"
           }
         },
         "fs-readdir-recursive": {
@@ -742,11 +742,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "globals": {
@@ -761,8 +761,8 @@
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "^1.0.1",
-            "user-home": "^1.1.1"
+            "os-tmpdir": "1.0.2",
+            "user-home": "1.1.1"
           }
         },
         "js-tokens": {
@@ -795,7 +795,7 @@
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
           "dev": true,
           "requires": {
-            "is-finite": "^1.0.0"
+            "is-finite": "1.0.2"
           }
         },
         "source-map-support": {
@@ -813,7 +813,7 @@
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
               "dev": true,
               "requires": {
-                "amdefine": ">=0.0.4"
+                "amdefine": "1.0.1"
               }
             }
           }
@@ -825,21 +825,21 @@
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
       "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-polyfill": "^6.26.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "chokidar": "^1.6.1",
-        "commander": "^2.11.0",
-        "convert-source-map": "^1.5.0",
-        "fs-readdir-recursive": "^1.0.0",
-        "glob": "^7.1.2",
-        "lodash": "^4.17.4",
-        "output-file-sync": "^1.1.2",
-        "path-is-absolute": "^1.0.1",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.6",
-        "v8flags": "^2.1.1"
+        "babel-core": "6.26.3",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "commander": "2.15.1",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "v8flags": "2.1.1"
       },
       "dependencies": {
         "commander": {
@@ -854,9 +854,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-core": {
@@ -864,25 +864,25 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "minimatch": {
@@ -890,7 +890,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -900,14 +900,14 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       }
     },
     "babel-helper-bindify-decorators": {
@@ -915,9 +915,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -925,9 +925,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-builder-react-jsx": {
@@ -935,9 +935,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
       "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "esutils": "^2.0.2"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "esutils": "2.0.2"
       }
     },
     "babel-helper-call-delegate": {
@@ -945,10 +945,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
@@ -956,10 +956,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -967,9 +967,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-explode-class": {
@@ -977,10 +977,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "requires": {
-        "babel-helper-bindify-decorators": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-bindify-decorators": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -988,11 +988,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -1000,8 +1000,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -1009,8 +1009,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-module-imports": {
@@ -1020,7 +1020,7 @@
       "dev": true,
       "requires": {
         "babel-types": "7.0.0-beta.3",
-        "lodash": "^4.2.0"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "babel-types": {
@@ -1029,9 +1029,9 @@
           "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
           }
         },
         "to-fast-properties": {
@@ -1047,8 +1047,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -1056,9 +1056,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1066,11 +1066,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
@@ -1078,12 +1078,12 @@
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -1091,8 +1091,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-loader": {
@@ -1100,10 +1100,10 @@
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
       "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
       "requires": {
-        "find-cache-dir": "^0.1.1",
-        "loader-utils": "^0.2.16",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.0.1"
+        "find-cache-dir": "0.1.1",
+        "loader-utils": "0.2.17",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "babel-messages": {
@@ -1111,7 +1111,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-add-module-exports": {
@@ -1124,7 +1124,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-constant-folding": {
@@ -1163,11 +1163,11 @@
       "integrity": "sha512-lNsptTRfc0FTdW56O087EiKEADVEjJo2frDQ97olMjCKbRZfZPu7MvdyxnZLOoDpuTCtavN8/4Zk65x4gT+C3Q==",
       "dev": true,
       "requires": {
-        "babel-helper-module-imports": "^7.0.0-beta.3",
-        "babel-types": "^6.26.0",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.4",
-        "require-package-name": "^2.0.1"
+        "babel-helper-module-imports": "7.0.0-beta.3",
+        "babel-types": "6.26.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "require-package-name": "2.0.1"
       }
     },
     "babel-plugin-member-expression-literals": {
@@ -1188,7 +1188,7 @@
       "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
       "dev": true,
       "requires": {
-        "lodash": "^3.9.3"
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "lodash": {
@@ -1305,7 +1305,7 @@
       "integrity": "sha1-Uhx4LTVkRJHJeepoPopeHK/wukI=",
       "optional": true,
       "requires": {
-        "babel-template": "^6.9.0"
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-async-generator-functions": {
@@ -1313,9 +1313,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-generators": "^6.5.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -1323,9 +1323,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-cjs-system-wrapper": {
@@ -1334,7 +1334,7 @@
       "integrity": "sha1-vXSUd1KJQk/0k7btRV3klb1xuh0=",
       "optional": true,
       "requires": {
-        "babel-template": "^6.9.0"
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-class-constructor-call": {
@@ -1342,9 +1342,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
       "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
       "requires": {
-        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-syntax-class-constructor-call": "6.18.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -1352,10 +1352,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-plugin-syntax-class-properties": "^6.8.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -1363,11 +1363,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "requires": {
-        "babel-helper-explode-class": "^6.24.1",
-        "babel-plugin-syntax-decorators": "^6.13.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-class": "6.24.1",
+        "babel-plugin-syntax-decorators": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-do-expressions": {
@@ -1375,8 +1375,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
       "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
       "requires": {
-        "babel-plugin-syntax-do-expressions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-do-expressions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1384,7 +1384,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1392,7 +1392,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1400,11 +1400,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1412,15 +1412,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -1428,8 +1428,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -1437,7 +1437,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1445,8 +1445,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -1454,7 +1454,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1462,9 +1462,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1472,7 +1472,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -1480,9 +1480,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1490,10 +1490,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1501,9 +1501,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1511,9 +1511,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1521,8 +1521,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1530,12 +1530,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1543,8 +1543,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1552,7 +1552,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1560,9 +1560,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1570,7 +1570,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1578,7 +1578,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1586,9 +1586,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       }
     },
     "babel-plugin-transform-es3-member-expression-literals": {
@@ -1596,7 +1596,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
       "integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es3-property-literals": {
@@ -1604,7 +1604,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
       "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1612,9 +1612,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-export-extensions": {
@@ -1622,8 +1622,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
       "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
       "requires": {
-        "babel-plugin-syntax-export-extensions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-export-extensions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -1631,8 +1631,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "requires": {
-        "babel-plugin-syntax-flow": "^6.18.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-function-bind": {
@@ -1640,8 +1640,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
       "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
       "requires": {
-        "babel-plugin-syntax-function-bind": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-function-bind": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-global-system-wrapper": {
@@ -1650,7 +1650,7 @@
       "integrity": "sha1-lI3X0p/CFEfjm9NEfy3rx/L3Oqw=",
       "optional": true,
       "requires": {
-        "babel-template": "^6.9.0"
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-object-assign": {
@@ -1658,7 +1658,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
       "integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1666,8 +1666,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-display-name": {
@@ -1675,7 +1675,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-jsx": {
@@ -1683,9 +1683,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
       "requires": {
-        "babel-helper-builder-react-jsx": "^6.24.1",
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-react-jsx": "6.26.0",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-jsx-self": {
@@ -1693,8 +1693,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
       "requires": {
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-jsx-source": {
@@ -1702,8 +1702,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
       "requires": {
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-pug": {
@@ -1713,13 +1713,13 @@
       "dev": true,
       "requires": {
         "babylon": "6.18.0",
-        "common-prefix": "^1.1.0",
-        "he": "^1.1.1",
-        "pug-error": "^1.3.2",
-        "pug-filters": "^3.0.1",
-        "pug-lexer": "^4.0.0",
-        "pug-parser": "^5.0.0",
-        "pug-strip-comments": "^1.0.3"
+        "common-prefix": "1.1.0",
+        "he": "1.1.1",
+        "pug-error": "1.3.2",
+        "pug-filters": "3.1.0",
+        "pug-lexer": "4.0.0",
+        "pug-parser": "5.0.0",
+        "pug-strip-comments": "1.0.3"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1727,7 +1727,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
-        "regenerator-transform": "^0.10.0"
+        "regenerator-transform": "0.10.1"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1735,8 +1735,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-system-register": {
@@ -1751,7 +1751,7 @@
       "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
       "dev": true,
       "requires": {
-        "leven": "^1.0.2"
+        "leven": "1.0.2"
       },
       "dependencies": {
         "leven": {
@@ -1773,9 +1773,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.6",
+        "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1790,36 +1790,36 @@
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
       "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^3.2.6",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "3.2.7",
+        "invariant": "2.2.4",
+        "semver": "5.5.0"
       }
     },
     "babel-preset-es2015": {
@@ -1827,30 +1827,30 @@
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-        "babel-plugin-transform-es2015-classes": "^6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-        "babel-plugin-transform-es2015-for-of": "^6.22.0",
-        "babel-plugin-transform-es2015-function-name": "^6.24.1",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-        "babel-plugin-transform-es2015-object-super": "^6.24.1",
-        "babel-plugin-transform-es2015-parameters": "^6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-        "babel-plugin-transform-regenerator": "^6.24.1"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
       }
     },
     "babel-preset-fbjs": {
@@ -1858,34 +1858,34 @@
       "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.1.4.tgz",
       "integrity": "sha512-6XVQwlO26V5/0P9s2Eje8Epqkv/ihaMJ798+W98ktOA8fCn2IFM6wEi7CDW3fTbKFZ/8fDGvGZH01B6GSuNiWA==",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.8.0",
-        "babel-plugin-syntax-class-properties": "^6.8.0",
-        "babel-plugin-syntax-flow": "^6.8.0",
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
-        "babel-plugin-transform-class-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.8.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.8.0",
-        "babel-plugin-transform-es2015-classes": "^6.8.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.8.0",
-        "babel-plugin-transform-es2015-for-of": "^6.8.0",
-        "babel-plugin-transform-es2015-function-name": "^6.8.0",
-        "babel-plugin-transform-es2015-literals": "^6.8.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
-        "babel-plugin-transform-es2015-object-super": "^6.8.0",
-        "babel-plugin-transform-es2015-parameters": "^6.8.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-spread": "^6.8.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.8.0",
-        "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
-        "babel-plugin-transform-es3-property-literals": "^6.8.0",
-        "babel-plugin-transform-flow-strip-types": "^6.8.0",
-        "babel-plugin-transform-object-rest-spread": "^6.8.0",
-        "babel-plugin-transform-react-display-name": "^6.8.0",
-        "babel-plugin-transform-react-jsx": "^6.8.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es3-member-expression-literals": "6.22.0",
+        "babel-plugin-transform-es3-property-literals": "6.22.0",
+        "babel-plugin-transform-flow-strip-types": "6.22.0",
+        "babel-plugin-transform-object-rest-spread": "6.26.0",
+        "babel-plugin-transform-react-display-name": "6.25.0",
+        "babel-plugin-transform-react-jsx": "6.24.1"
       }
     },
     "babel-preset-flow": {
@@ -1893,7 +1893,7 @@
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "^6.22.0"
+        "babel-plugin-transform-flow-strip-types": "6.22.0"
       }
     },
     "babel-preset-react": {
@@ -1901,12 +1901,12 @@
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
       "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
       "requires": {
-        "babel-plugin-syntax-jsx": "^6.3.13",
-        "babel-plugin-transform-react-display-name": "^6.23.0",
-        "babel-plugin-transform-react-jsx": "^6.24.1",
-        "babel-plugin-transform-react-jsx-self": "^6.22.0",
-        "babel-plugin-transform-react-jsx-source": "^6.22.0",
-        "babel-preset-flow": "^6.23.0"
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-plugin-transform-react-display-name": "6.25.0",
+        "babel-plugin-transform-react-jsx": "6.24.1",
+        "babel-plugin-transform-react-jsx-self": "6.22.0",
+        "babel-plugin-transform-react-jsx-source": "6.22.0",
+        "babel-preset-flow": "6.23.0"
       }
     },
     "babel-preset-stage-0": {
@@ -1914,9 +1914,9 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
       "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
       "requires": {
-        "babel-plugin-transform-do-expressions": "^6.22.0",
-        "babel-plugin-transform-function-bind": "^6.22.0",
-        "babel-preset-stage-1": "^6.24.1"
+        "babel-plugin-transform-do-expressions": "6.22.0",
+        "babel-plugin-transform-function-bind": "6.22.0",
+        "babel-preset-stage-1": "6.24.1"
       }
     },
     "babel-preset-stage-1": {
@@ -1924,9 +1924,9 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
       "requires": {
-        "babel-plugin-transform-class-constructor-call": "^6.24.1",
-        "babel-plugin-transform-export-extensions": "^6.22.0",
-        "babel-preset-stage-2": "^6.24.1"
+        "babel-plugin-transform-class-constructor-call": "6.24.1",
+        "babel-plugin-transform-export-extensions": "6.22.0",
+        "babel-preset-stage-2": "6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -1934,10 +1934,10 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-plugin-transform-class-properties": "^6.24.1",
-        "babel-plugin-transform-decorators": "^6.24.1",
-        "babel-preset-stage-3": "^6.24.1"
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-decorators": "6.24.1",
+        "babel-preset-stage-3": "6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -1945,11 +1945,11 @@
       "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-generator-functions": "^6.24.1",
-        "babel-plugin-transform-async-to-generator": "^6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
-        "babel-plugin-transform-object-rest-spread": "^6.22.0"
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-generator-functions": "6.24.1",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-object-rest-spread": "6.26.0"
       }
     },
     "babel-register": {
@@ -1957,13 +1957,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.6",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -1971,8 +1971,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.6",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-template": {
@@ -1980,11 +1980,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-traverse": {
@@ -1992,15 +1992,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
       }
     },
     "babel-types": {
@@ -2008,10 +2008,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -2039,13 +2039,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2053,7 +2053,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -2061,7 +2061,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2069,7 +2069,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2077,9 +2077,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -2104,7 +2104,7 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
       "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "base64-arraybuffer": {
@@ -2137,13 +2137,13 @@
       "resolved": "https://registry.npmjs.org/bash-glob/-/bash-glob-1.0.2.tgz",
       "integrity": "sha512-E0TTxH9T/tklSXt5R5X0zwxjW56su2VIE+sAruXbd8AtMjYZxtvioybVdptbRk0/0Nvdz0TVVShKhN9sH5dMpg==",
       "requires": {
-        "async-each": "^1.0.1",
-        "bash-path": "^1.0.1",
-        "component-emitter": "^1.2.1",
-        "cross-spawn": "^5.1.0",
-        "extend-shallow": "^2.0.1",
-        "is-extglob": "^2.1.1",
-        "is-glob": "^4.0.0"
+        "async-each": "1.0.1",
+        "bash-path": "1.0.3",
+        "component-emitter": "1.2.1",
+        "cross-spawn": "5.1.0",
+        "extend-shallow": "2.0.1",
+        "is-extglob": "2.1.1",
+        "is-glob": "4.0.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2151,7 +2151,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-extglob": {
@@ -2164,7 +2164,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -2174,8 +2174,8 @@
       "resolved": "https://registry.npmjs.org/bash-path/-/bash-path-1.0.3.tgz",
       "integrity": "sha512-mGrYvOa6yTY/qNCiZkPFJqWmODK68y6kmVRAJ1NNbWlNoJrUrsFxu7FU2EKg7gbrer6ttrKkF2s/E/lhRy7/OA==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "is-windows": "^1.0.1"
+        "arr-union": "3.1.0",
+        "is-windows": "1.0.2"
       }
     },
     "basic-auth": {
@@ -2204,7 +2204,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -2225,9 +2225,9 @@
       "resolved": "https://registry.npmjs.org/better-queue/-/better-queue-3.8.7.tgz",
       "integrity": "sha512-OD1yiyXPwIcoicNFeV1hLf4HkmB4V60Pm+hnYsmfY2+HJO5A0nR8vFuJyTjuNxLlGWfv2a4RFq1TRHbxvQNizw==",
       "requires": {
-        "better-queue-memory": "^1.0.1",
-        "node-eta": "^0.9.0",
-        "uuid": "^3.0.0"
+        "better-queue-memory": "1.0.2",
+        "node-eta": "0.9.0",
+        "uuid": "3.2.1"
       }
     },
     "better-queue-memory": {
@@ -2250,13 +2250,13 @@
       "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
       "integrity": "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=",
       "requires": {
-        "archive-type": "^3.0.1",
-        "decompress": "^3.0.0",
-        "download": "^4.1.2",
-        "exec-series": "^1.0.0",
-        "rimraf": "^2.2.6",
-        "tempfile": "^1.0.0",
-        "url-regex": "^3.0.0"
+        "archive-type": "3.2.0",
+        "decompress": "3.0.0",
+        "download": "4.4.3",
+        "exec-series": "1.0.3",
+        "rimraf": "2.6.2",
+        "tempfile": "1.1.1",
+        "url-regex": "3.2.0"
       },
       "dependencies": {
         "tempfile": {
@@ -2264,8 +2264,8 @@
           "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
           "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
           "requires": {
-            "os-tmpdir": "^1.0.0",
-            "uuid": "^2.0.1"
+            "os-tmpdir": "1.0.2",
+            "uuid": "2.0.3"
           }
         },
         "uuid": {
@@ -2280,7 +2280,7 @@
       "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
       "integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
       "requires": {
-        "executable": "^1.0.0"
+        "executable": "1.1.0"
       }
     },
     "bin-version": {
@@ -2288,7 +2288,7 @@
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
       "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
       "requires": {
-        "find-versions": "^1.0.0"
+        "find-versions": "1.2.1"
       }
     },
     "bin-version-check": {
@@ -2296,10 +2296,10 @@
       "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
       "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
       "requires": {
-        "bin-version": "^1.0.0",
-        "minimist": "^1.1.0",
-        "semver": "^4.0.3",
-        "semver-truncate": "^1.0.0"
+        "bin-version": "1.0.4",
+        "minimist": "1.2.0",
+        "semver": "4.3.6",
+        "semver-truncate": "1.1.2"
       },
       "dependencies": {
         "semver": {
@@ -2314,12 +2314,12 @@
       "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
       "integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
       "requires": {
-        "bin-check": "^2.0.0",
-        "bin-version-check": "^2.1.0",
-        "download": "^4.0.0",
-        "each-async": "^1.1.1",
-        "lazy-req": "^1.0.0",
-        "os-filter-obj": "^1.0.0"
+        "bin-check": "2.0.0",
+        "bin-version-check": "2.1.0",
+        "download": "4.4.3",
+        "each-async": "1.1.1",
+        "lazy-req": "1.1.0",
+        "os-filter-obj": "1.0.3"
       }
     },
     "binary-extensions": {
@@ -2332,8 +2332,8 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "blob": {
@@ -2362,15 +2362,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.19",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
+        "type-is": "1.6.16"
       }
     },
     "boolbase": {
@@ -2383,7 +2383,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "boxen": {
@@ -2391,13 +2391,13 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.4.1",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2405,7 +2405,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -2413,9 +2413,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -2428,7 +2428,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2438,7 +2438,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -2447,9 +2447,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "breakable": {
@@ -2483,12 +2483,12 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-cipher": {
@@ -2496,9 +2496,9 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.1",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -2506,9 +2506,9 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
       "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
       }
     },
     "browserify-optional": {
@@ -2517,8 +2517,8 @@
       "integrity": "sha1-HhNyLP3g2F8SFnbCpyztUzoBiGk=",
       "requires": {
         "ast-transform": "0.0.0",
-        "ast-types": "^0.7.0",
-        "browser-resolve": "^1.8.1"
+        "ast-types": "0.7.8",
+        "browser-resolve": "1.11.2"
       }
     },
     "browserify-rsa": {
@@ -2526,8 +2526,8 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -2535,13 +2535,13 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.1"
       }
     },
     "browserify-zlib": {
@@ -2549,7 +2549,7 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
-        "pako": "~1.0.5"
+        "pako": "1.0.6"
       }
     },
     "browserslist": {
@@ -2557,8 +2557,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
       "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30000835",
-        "electron-to-chromium": "^1.3.45"
+        "caniuse-lite": "1.0.30000839",
+        "electron-to-chromium": "1.3.45"
       }
     },
     "bser": {
@@ -2566,7 +2566,7 @@
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "requires": {
-        "node-int64": "^0.4.0"
+        "node-int64": "0.4.0"
       }
     },
     "buffer": {
@@ -2574,9 +2574,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.11",
+        "isarray": "1.0.0"
       }
     },
     "buffer-alloc": {
@@ -2584,8 +2584,8 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
       "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
       "requires": {
-        "buffer-alloc-unsafe": "^0.1.0",
-        "buffer-fill": "^0.1.0"
+        "buffer-alloc-unsafe": "0.1.1",
+        "buffer-fill": "0.1.1"
       }
     },
     "buffer-alloc-unsafe": {
@@ -2624,10 +2624,10 @@
       "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
       "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
       "requires": {
-        "file-type": "^3.1.0",
-        "readable-stream": "^2.0.2",
-        "uuid": "^2.0.1",
-        "vinyl": "^1.0.0"
+        "file-type": "3.9.0",
+        "readable-stream": "2.3.6",
+        "uuid": "2.0.3",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "file-type": {
@@ -2653,7 +2653,7 @@
       "integrity": "sha1-z7GtlWjTujz+k1upq92VLeiKqyo=",
       "dev": true,
       "requires": {
-        "readable-stream": "^1.0.33"
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -2668,10 +2668,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -2702,15 +2702,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -2731,7 +2731,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsite": {
@@ -2755,8 +2755,8 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -2771,10 +2771,10 @@
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
-        "browserslist": "^1.3.6",
-        "caniuse-db": "^1.0.30000529",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000839",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
       },
       "dependencies": {
         "browserslist": {
@@ -2782,8 +2782,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000839",
+            "electron-to-chromium": "1.3.45"
           }
         }
       }
@@ -2814,7 +2814,7 @@
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
-        "underscore-contrib": "~0.3.0"
+        "underscore-contrib": "0.3.0"
       }
     },
     "caw": {
@@ -2822,10 +2822,10 @@
       "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
       "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
       "requires": {
-        "get-proxy": "^1.0.1",
-        "is-obj": "^1.0.0",
-        "object-assign": "^3.0.0",
-        "tunnel-agent": "^0.4.0"
+        "get-proxy": "1.1.0",
+        "is-obj": "1.0.1",
+        "object-assign": "3.0.0",
+        "tunnel-agent": "0.4.3"
       },
       "dependencies": {
         "object-assign": {
@@ -2850,8 +2850,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chalk": {
@@ -2859,11 +2859,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "character-entities": {
@@ -2887,7 +2887,7 @@
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "dev": true,
       "requires": {
-        "is-regex": "^1.0.3"
+        "is-regex": "1.0.4"
       }
     },
     "character-reference-invalid": {
@@ -2910,22 +2910,22 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash.assignin": "^4.0.9",
-        "lodash.bind": "^4.1.4",
-        "lodash.defaults": "^4.0.1",
-        "lodash.filter": "^4.4.0",
-        "lodash.flatten": "^4.2.0",
-        "lodash.foreach": "^4.3.0",
-        "lodash.map": "^4.4.0",
-        "lodash.merge": "^4.4.0",
-        "lodash.pick": "^4.2.1",
-        "lodash.reduce": "^4.4.0",
-        "lodash.reject": "^4.4.0",
-        "lodash.some": "^4.4.0"
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash.assignin": "4.2.0",
+        "lodash.bind": "4.2.1",
+        "lodash.defaults": "4.2.0",
+        "lodash.filter": "4.6.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.foreach": "4.5.0",
+        "lodash.map": "4.6.0",
+        "lodash.merge": "4.6.1",
+        "lodash.pick": "4.4.0",
+        "lodash.reduce": "4.6.0",
+        "lodash.reject": "4.6.0",
+        "lodash.some": "4.6.0"
       },
       "dependencies": {
         "domhandler": {
@@ -2933,7 +2933,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "htmlparser2": {
@@ -2941,12 +2941,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.2",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         }
       }
@@ -2956,15 +2956,15 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.3",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "chownr": {
@@ -2977,7 +2977,7 @@
       "resolved": "https://registry.npmjs.org/chunk-manifest-webpack-plugin/-/chunk-manifest-webpack-plugin-0.1.0.tgz",
       "integrity": "sha1-YThIj8Id2rTM+3wcEdUbuAqUMYY=",
       "requires": {
-        "webpack-core": "^0.4.8"
+        "webpack-core": "0.4.8"
       }
     },
     "ci-info": {
@@ -2990,8 +2990,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "circular-json": {
@@ -3005,7 +3005,7 @@
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "requires": {
-        "chalk": "^1.1.3"
+        "chalk": "1.1.3"
       }
     },
     "class-utils": {
@@ -3013,10 +3013,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -3024,7 +3024,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "isobject": {
@@ -3045,7 +3045,7 @@
       "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.x"
+        "source-map": "0.5.7"
       }
     },
     "cli-boxes": {
@@ -3058,7 +3058,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-glob": {
@@ -3067,9 +3067,9 @@
       "integrity": "sha1-C6xj8XjbvRB4YRk6ckgSSn4f+bY=",
       "dev": true,
       "requires": {
-        "es6-promise": "^3.0.2",
-        "glob": "^6.0.1",
-        "minimist": "^1.2.0"
+        "es6-promise": "3.3.1",
+        "glob": "6.0.4",
+        "minimist": "1.2.0"
       },
       "dependencies": {
         "es6-promise": {
@@ -3084,11 +3084,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -3104,9 +3104,9 @@
       "integrity": "sha512-7yhQBmtN+uYZmfRjjVjKa0dZdWuabzpSKGtyQZN+9C8xlC788SSJjOHWh7tzurfwTqTD5UDYAhIv5fRJg3sHjQ==",
       "optional": true,
       "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
       }
     },
     "clipboardy": {
@@ -3114,8 +3114,8 @@
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
       "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
       "requires": {
-        "arch": "^2.1.0",
-        "execa": "^0.8.0"
+        "arch": "2.1.0",
+        "execa": "0.8.0"
       }
     },
     "cliui": {
@@ -3123,9 +3123,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3138,7 +3138,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -3159,8 +3159,8 @@
       "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
       "dev": true,
       "requires": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
+        "is-regexp": "1.0.0",
+        "is-supported-regexp-flag": "1.0.1"
       }
     },
     "clone-stats": {
@@ -3173,9 +3173,9 @@
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "co": {
@@ -3188,7 +3188,7 @@
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "requires": {
-        "q": "^1.1.2"
+        "q": "1.5.1"
       }
     },
     "code-point-at": {
@@ -3206,8 +3206,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color": {
@@ -3215,9 +3215,9 @@
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "requires": {
-        "clone": "^1.0.2",
-        "color-convert": "^1.3.0",
-        "color-string": "^0.3.0"
+        "clone": "1.0.4",
+        "color-convert": "1.9.1",
+        "color-string": "0.3.0"
       }
     },
     "color-convert": {
@@ -3225,7 +3225,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-diff": {
@@ -3244,7 +3244,7 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "requires": {
-        "color-name": "^1.0.0"
+        "color-name": "1.1.3"
       }
     },
     "color-support": {
@@ -3258,16 +3258,16 @@
       "integrity": "sha512-qYVKTg626qpDg4/eBnPXidEPXn5+krbYqHVfyyEFBWV5z3IF4p44HKY/eE2t1ohlcrlIkDgHmFJMfQ8qMLnSFw==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "color-diff": "^0.1.3",
-        "log-symbols": "^1.0.2",
-        "object-assign": "^4.0.1",
-        "pipetteur": "^2.0.0",
-        "plur": "^2.0.0",
-        "postcss": "^5.0.4",
-        "postcss-reporter": "^1.2.1",
-        "text-table": "^0.2.0",
-        "yargs": "^1.2.6"
+        "chalk": "1.1.3",
+        "color-diff": "0.1.7",
+        "log-symbols": "1.0.2",
+        "object-assign": "4.1.1",
+        "pipetteur": "2.0.3",
+        "plur": "2.1.2",
+        "postcss": "5.2.18",
+        "postcss-reporter": "1.4.1",
+        "text-table": "0.2.0",
+        "yargs": "1.3.3"
       },
       "dependencies": {
         "yargs": {
@@ -3283,9 +3283,9 @@
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "requires": {
-        "color": "^0.11.0",
+        "color": "0.11.4",
         "css-color-names": "0.0.4",
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "colors": {
@@ -3298,7 +3298,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "comma-separated-tokens": {
@@ -3319,7 +3319,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "requires": {
-        "graceful-readlink": ">= 1.0.0"
+        "graceful-readlink": "1.0.1"
       }
     },
     "common-prefix": {
@@ -3333,7 +3333,7 @@
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
       "integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "commondir": {
@@ -3347,15 +3347,15 @@
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
       "dev": true,
       "requires": {
-        "commander": "^2.5.0",
-        "detective": "^4.3.1",
-        "glob": "^5.0.15",
-        "graceful-fs": "^4.1.2",
-        "iconv-lite": "^0.4.5",
-        "mkdirp": "^0.5.0",
-        "private": "^0.1.6",
-        "q": "^1.1.2",
-        "recast": "^0.11.17"
+        "commander": "2.9.0",
+        "detective": "4.7.1",
+        "glob": "5.0.15",
+        "graceful-fs": "4.1.11",
+        "iconv-lite": "0.4.19",
+        "mkdirp": "0.5.1",
+        "private": "0.1.8",
+        "q": "1.5.1",
+        "recast": "0.11.23"
       },
       "dependencies": {
         "ast-types": {
@@ -3376,11 +3376,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "recast": {
@@ -3390,9 +3390,9 @@
           "dev": true,
           "requires": {
             "ast-types": "0.9.6",
-            "esprima": "~3.1.0",
-            "private": "~0.1.5",
-            "source-map": "~0.5.0"
+            "esprima": "3.1.3",
+            "private": "0.1.8",
+            "source-map": "0.5.7"
           }
         }
       }
@@ -3417,7 +3417,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
       "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
       "requires": {
-        "mime-db": ">= 1.33.0 < 2"
+        "mime-db": "1.33.0"
       }
     },
     "compression": {
@@ -3425,13 +3425,13 @@
       "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.13",
+        "compressible": "2.0.13",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1",
+        "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -3451,10 +3451,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "concat-with-sourcemaps": {
@@ -3463,7 +3463,7 @@
       "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
       "dev": true,
       "requires": {
-        "source-map": "^0.6.1"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -3479,12 +3479,12 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.3.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "connect-history-api-fallback": {
@@ -3497,7 +3497,7 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "console-control-strings": {
@@ -3516,10 +3516,10 @@
       "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "^7.0.0",
-        "@types/babylon": "^6.16.2",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0"
+        "@types/babel-types": "7.0.2",
+        "@types/babylon": "6.16.2",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0"
       }
     },
     "constants-browserify": {
@@ -3573,12 +3573,12 @@
       "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-1.2.0.tgz",
       "integrity": "sha1-qNo6xBqiIgrim9PFi2mEKU8sWTw=",
       "requires": {
-        "glob": "^7.0.5",
-        "ltcdr": "^2.2.1",
-        "minimatch": "^3.0.3",
-        "mkdirp": "^0.5.1",
+        "glob": "7.1.2",
+        "ltcdr": "2.2.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
         "noms": "0.0.0",
-        "through2": "^2.0.1"
+        "through2": "2.0.3"
       },
       "dependencies": {
         "minimatch": {
@@ -3586,7 +3586,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -3607,13 +3607,13 @@
       "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
       "dev": true,
       "requires": {
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.4.3",
-        "minimist": "^1.2.0",
-        "object-assign": "^4.1.0",
-        "os-homedir": "^1.0.1",
-        "parse-json": "^2.2.0",
-        "require-from-string": "^1.1.0"
+        "is-directory": "0.3.1",
+        "js-yaml": "3.7.0",
+        "minimist": "1.2.0",
+        "object-assign": "4.1.1",
+        "os-homedir": "1.0.2",
+        "parse-json": "2.2.0",
+        "require-from-string": "1.2.1"
       }
     },
     "create-ecdh": {
@@ -3621,8 +3621,8 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
       }
     },
     "create-error-class": {
@@ -3630,7 +3630,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "create-hash": {
@@ -3638,11 +3638,11 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.4",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -3650,12 +3650,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-react-class": {
@@ -3663,9 +3663,9 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
       "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       }
     },
     "cross-env": {
@@ -3673,8 +3673,8 @@
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-3.2.4.tgz",
       "integrity": "sha1-ngWF8neGTtQhznVvgamA/w1piro=",
       "requires": {
-        "cross-spawn": "^5.1.0",
-        "is-windows": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "is-windows": "1.0.2"
       }
     },
     "cross-spawn": {
@@ -3682,9 +3682,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "crypt": {
@@ -3697,7 +3697,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -3705,7 +3705,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -3715,17 +3715,17 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.1",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.3",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "diffie-hellman": "5.0.3",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.16",
+        "public-encrypt": "4.0.2",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.4"
       }
     },
     "crypto-js": {
@@ -3744,9 +3744,9 @@
       "integrity": "sha1-jtJMLAIFBzM5+voAS8jBQfzLKC4=",
       "requires": {
         "balanced-match": "0.1.0",
-        "color": "^0.11.0",
-        "debug": "^3.1.0",
-        "rgb": "~0.1.0"
+        "color": "0.11.4",
+        "debug": "3.1.0",
+        "rgb": "0.1.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -3796,18 +3796,18 @@
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.26.4.tgz",
       "integrity": "sha1-th6eMNuUMD5v/IkvEOzQmtAlof0=",
       "requires": {
-        "babel-code-frame": "^6.11.0",
-        "css-selector-tokenizer": "^0.7.0",
-        "cssnano": ">=2.6.1 <4",
-        "loader-utils": "^1.0.2",
-        "lodash.camelcase": "^4.3.0",
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.6",
-        "postcss-modules-extract-imports": "^1.0.0",
-        "postcss-modules-local-by-default": "^1.0.1",
-        "postcss-modules-scope": "^1.0.0",
-        "postcss-modules-values": "^1.1.0",
-        "source-list-map": "^0.1.7"
+        "babel-code-frame": "6.26.0",
+        "css-selector-tokenizer": "0.7.0",
+        "cssnano": "3.10.0",
+        "loader-utils": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-modules-extract-imports": "1.1.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "source-list-map": "0.1.8"
       },
       "dependencies": {
         "loader-utils": {
@@ -3815,9 +3815,9 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         }
       }
@@ -3828,10 +3828,10 @@
       "integrity": "sha1-N4bnGYmD2WWibjGVfgkHjLt3BaI=",
       "dev": true,
       "requires": {
-        "css-tokenize": "^1.0.1",
+        "css-tokenize": "1.0.1",
         "duplexer2": "0.0.2",
-        "ldjson-stream": "^1.2.1",
-        "through2": "^0.6.3"
+        "ldjson-stream": "1.2.1",
+        "through2": "0.6.5"
       },
       "dependencies": {
         "duplexer2": {
@@ -3840,7 +3840,7 @@
           "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.1.9"
+            "readable-stream": "1.1.14"
           }
         },
         "isarray": {
@@ -3855,10 +3855,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3873,8 +3873,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           },
           "dependencies": {
             "readable-stream": {
@@ -3883,10 +3883,10 @@
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             }
           }
@@ -3898,10 +3898,10 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
         "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
+        "nth-check": "1.0.1"
       }
     },
     "css-selector-parser": {
@@ -3914,9 +3914,9 @@
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "requires": {
-        "cssesc": "^0.1.0",
-        "fastparse": "^1.1.1",
-        "regexpu-core": "^1.0.0"
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.1",
+        "regexpu-core": "1.0.0"
       },
       "dependencies": {
         "regexpu-core": {
@@ -3924,9 +3924,9 @@
           "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
           }
         }
       }
@@ -3936,9 +3936,9 @@
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.0.tgz",
       "integrity": "sha512-SWG8+tsVRBHpxn1cSDmx7B95DJCiKwUecBbboGpm2znDCnJDMGkcoYR73w1p2IZMab6iNqVms8VC+4TrSqoFeQ==",
       "requires": {
-        "css-color-keywords": "^1.0.0",
-        "fbjs": "^0.8.5",
-        "postcss-value-parser": "^3.3.0"
+        "css-color-keywords": "1.0.0",
+        "fbjs": "0.8.16",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "css-tokenize": {
@@ -3947,8 +3947,8 @@
       "integrity": "sha1-RiXLHtohwUOFi3+B1oA8HSb8FL4=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^1.0.33"
+        "inherits": "2.0.3",
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -3963,10 +3963,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3992,38 +3992,38 @@
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "requires": {
-        "autoprefixer": "^6.3.1",
-        "decamelize": "^1.1.2",
-        "defined": "^1.0.0",
-        "has": "^1.0.1",
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.14",
-        "postcss-calc": "^5.2.0",
-        "postcss-colormin": "^2.1.8",
-        "postcss-convert-values": "^2.3.4",
-        "postcss-discard-comments": "^2.0.4",
-        "postcss-discard-duplicates": "^2.0.1",
-        "postcss-discard-empty": "^2.0.1",
-        "postcss-discard-overridden": "^0.1.1",
-        "postcss-discard-unused": "^2.2.1",
-        "postcss-filter-plugins": "^2.0.0",
-        "postcss-merge-idents": "^2.1.5",
-        "postcss-merge-longhand": "^2.0.1",
-        "postcss-merge-rules": "^2.0.3",
-        "postcss-minify-font-values": "^1.0.2",
-        "postcss-minify-gradients": "^1.0.1",
-        "postcss-minify-params": "^1.0.4",
-        "postcss-minify-selectors": "^2.0.4",
-        "postcss-normalize-charset": "^1.1.0",
-        "postcss-normalize-url": "^3.0.7",
-        "postcss-ordered-values": "^2.1.0",
-        "postcss-reduce-idents": "^2.2.2",
-        "postcss-reduce-initial": "^1.0.0",
-        "postcss-reduce-transforms": "^1.0.3",
-        "postcss-svgo": "^2.1.1",
-        "postcss-unique-selectors": "^2.0.2",
-        "postcss-value-parser": "^3.2.3",
-        "postcss-zindex": "^2.0.1"
+        "autoprefixer": "6.7.7",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.2",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
       }
     },
     "csso": {
@@ -4031,8 +4031,8 @@
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "requires": {
-        "clap": "^1.0.9",
-        "source-map": "^0.5.3"
+        "clap": "1.2.3",
+        "source-map": "0.5.7"
       }
     },
     "csstype": {
@@ -4045,7 +4045,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "cwebp-bin": {
@@ -4053,9 +4053,9 @@
       "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-4.0.0.tgz",
       "integrity": "sha1-7it/YzPTQm+1K7QF+m8uyLYolPQ=",
       "requires": {
-        "bin-build": "^2.2.0",
-        "bin-wrapper": "^3.0.1",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "d": {
@@ -4063,7 +4063,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.42"
       }
     },
     "damerau-levenshtein": {
@@ -4082,7 +4082,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "data-uri-to-buffer": {
@@ -4125,8 +4125,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
       }
     },
     "decode-uri-component": {
@@ -4139,15 +4139,15 @@
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
       "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
       "requires": {
-        "buffer-to-vinyl": "^1.0.0",
-        "concat-stream": "^1.4.6",
-        "decompress-tar": "^3.0.0",
-        "decompress-tarbz2": "^3.0.0",
-        "decompress-targz": "^3.0.0",
-        "decompress-unzip": "^3.0.0",
-        "stream-combiner2": "^1.1.1",
-        "vinyl-assign": "^1.0.1",
-        "vinyl-fs": "^2.2.0"
+        "buffer-to-vinyl": "1.1.0",
+        "concat-stream": "1.6.2",
+        "decompress-tar": "3.1.0",
+        "decompress-tarbz2": "3.1.0",
+        "decompress-targz": "3.1.0",
+        "decompress-unzip": "3.4.0",
+        "stream-combiner2": "1.1.1",
+        "vinyl-assign": "1.2.1",
+        "vinyl-fs": "2.4.4"
       }
     },
     "decompress-response": {
@@ -4155,7 +4155,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.0"
       }
     },
     "decompress-tar": {
@@ -4163,12 +4163,12 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
       "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
       "requires": {
-        "is-tar": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-tar": "1.0.0",
+        "object-assign": "2.1.1",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.6.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -4191,10 +4191,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -4207,8 +4207,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -4216,8 +4216,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -4227,13 +4227,13 @@
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
       "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
       "requires": {
-        "is-bzip2": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "seek-bzip": "^1.0.3",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-bzip2": "1.0.0",
+        "object-assign": "2.1.1",
+        "seek-bzip": "1.0.5",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.6.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -4256,10 +4256,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -4272,8 +4272,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -4281,8 +4281,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -4292,12 +4292,12 @@
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
       "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
       "requires": {
-        "is-gzip": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-gzip": "1.0.0",
+        "object-assign": "2.1.1",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.6.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -4320,10 +4320,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -4336,8 +4336,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -4345,8 +4345,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -4356,13 +4356,13 @@
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
       "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
       "requires": {
-        "is-zip": "^1.0.0",
-        "read-all-stream": "^3.0.0",
-        "stat-mode": "^0.2.0",
-        "strip-dirs": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0",
-        "yauzl": "^2.2.1"
+        "is-zip": "1.0.0",
+        "read-all-stream": "3.1.0",
+        "stat-mode": "0.2.2",
+        "strip-dirs": "1.1.1",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0",
+        "yauzl": "2.9.1"
       }
     },
     "deep-equal": {
@@ -4392,7 +4392,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.4"
       }
     },
     "define-properties": {
@@ -4400,8 +4400,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "define-property": {
@@ -4409,8 +4409,8 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -4418,7 +4418,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4426,7 +4426,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -4434,9 +4434,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -4462,16 +4462,16 @@
       "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
       "dev": true,
       "requires": {
-        "alter": "~0.2.0",
-        "ast-traverse": "~0.1.1",
-        "breakable": "~1.0.0",
-        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
-        "simple-fmt": "~0.1.0",
-        "simple-is": "~0.2.0",
-        "stringmap": "~0.2.2",
-        "stringset": "~0.2.1",
-        "tryor": "~0.1.2",
-        "yargs": "~3.27.0"
+        "alter": "0.2.0",
+        "ast-traverse": "0.1.1",
+        "breakable": "1.0.0",
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "simple-fmt": "0.1.0",
+        "simple-is": "0.2.0",
+        "stringmap": "0.2.2",
+        "stringset": "0.2.1",
+        "tryor": "0.1.2",
+        "yargs": "3.27.0"
       },
       "dependencies": {
         "camelcase": {
@@ -4486,8 +4486,8 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -4503,7 +4503,7 @@
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "window-size": {
@@ -4518,12 +4518,12 @@
           "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
           "dev": true,
           "requires": {
-            "camelcase": "^1.2.1",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "os-locale": "^1.4.0",
-            "window-size": "^0.1.2",
-            "y18n": "^3.2.0"
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
           }
         }
       }
@@ -4533,12 +4533,12 @@
       "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -4573,8 +4573,8 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "destroy": {
@@ -4587,7 +4587,7 @@
       "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.1.tgz",
       "integrity": "sha512-/hhdqdQc5thGrqzjyO/pz76lDZ5GSuAs6goxOaKTsvPk7HNnzAyFN5lyHgqpX4/s1i66K8qMGj+VhA9504x7DQ==",
       "requires": {
-        "repeat-string": "^1.5.4"
+        "repeat-string": "1.6.1"
       }
     },
     "detect-file": {
@@ -4600,7 +4600,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detect-libc": {
@@ -4613,8 +4613,8 @@
       "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.2.2.tgz",
       "integrity": "sha512-06H99JMCwgbYbA+codm97aBhFLAjABftetp+v+Z88Pvvlkawp2N+1bP/9J24+mihrvk9yBvUYTyIj3NixG1CsA==",
       "requires": {
-        "address": "^1.0.1",
-        "debug": "^2.6.0"
+        "address": "1.0.3",
+        "debug": "2.6.9"
       }
     },
     "detective": {
@@ -4623,8 +4623,8 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "^5.2.1",
-        "defined": "^1.0.0"
+        "acorn": "5.5.3",
+        "defined": "1.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -4640,22 +4640,22 @@
       "resolved": "https://registry.npmjs.org/devcert-san/-/devcert-san-0.3.3.tgz",
       "integrity": "sha1-qnckR0Gy2DF3HAEfIu4l45atS6k=",
       "requires": {
-        "@types/configstore": "^2.1.1",
-        "@types/debug": "^0.0.29",
-        "@types/get-port": "^0.0.4",
-        "@types/glob": "^5.0.30",
-        "@types/mkdirp": "^0.3.29",
-        "@types/node": "^7.0.11",
-        "@types/tmp": "^0.0.32",
-        "command-exists": "^1.2.2",
-        "configstore": "^3.0.0",
-        "debug": "^2.6.3",
-        "eol": "^0.8.1",
-        "get-port": "^3.0.0",
-        "glob": "^7.1.1",
-        "mkdirp": "^0.5.1",
-        "tmp": "^0.0.31",
-        "tslib": "^1.6.0"
+        "@types/configstore": "2.1.1",
+        "@types/debug": "0.0.29",
+        "@types/get-port": "0.0.4",
+        "@types/glob": "5.0.35",
+        "@types/mkdirp": "0.3.29",
+        "@types/node": "7.0.64",
+        "@types/tmp": "0.0.32",
+        "command-exists": "1.2.6",
+        "configstore": "3.1.2",
+        "debug": "2.6.9",
+        "eol": "0.8.1",
+        "get-port": "3.2.0",
+        "glob": "7.1.2",
+        "mkdirp": "0.5.1",
+        "tmp": "0.0.31",
+        "tslib": "1.9.0"
       }
     },
     "diff": {
@@ -4669,9 +4669,9 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
       }
     },
     "dir-glob": {
@@ -4680,8 +4680,8 @@
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
       },
       "dependencies": {
         "path-type": {
@@ -4690,7 +4690,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         }
       }
@@ -4701,7 +4701,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "doiuse": {
@@ -4710,18 +4710,18 @@
       "integrity": "sha1-GJLRC2Gpo1at2/K2FJM+gfi7ODQ=",
       "dev": true,
       "requires": {
-        "browserslist": "^1.1.1",
-        "caniuse-db": "^1.0.30000187",
-        "css-rule-stream": "^1.1.0",
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000839",
+        "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
-        "jsonfilter": "^1.1.2",
-        "ldjson-stream": "^1.2.1",
-        "lodash": "^4.0.0",
-        "multimatch": "^2.0.0",
-        "postcss": "^5.0.8",
-        "source-map": "^0.4.2",
-        "through2": "^0.6.3",
-        "yargs": "^3.5.4"
+        "jsonfilter": "1.1.2",
+        "ldjson-stream": "1.2.1",
+        "lodash": "4.17.10",
+        "multimatch": "2.0.0",
+        "postcss": "5.2.18",
+        "source-map": "0.4.4",
+        "through2": "0.6.5",
+        "yargs": "3.32.0"
       },
       "dependencies": {
         "browserslist": {
@@ -4730,8 +4730,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000839",
+            "electron-to-chromium": "1.3.45"
           }
         },
         "camelcase": {
@@ -4746,9 +4746,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "duplexer2": {
@@ -4757,7 +4757,7 @@
           "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.1.9"
+            "readable-stream": "1.1.14"
           }
         },
         "is-fullwidth-code-point": {
@@ -4766,7 +4766,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -4781,7 +4781,7 @@
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "readable-stream": {
@@ -4790,10 +4790,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "source-map": {
@@ -4802,7 +4802,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "string-width": {
@@ -4811,9 +4811,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -4828,8 +4828,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           },
           "dependencies": {
             "readable-stream": {
@@ -4838,10 +4838,10 @@
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             }
           }
@@ -4858,13 +4858,13 @@
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "dev": true,
           "requires": {
-            "camelcase": "^2.0.1",
-            "cliui": "^3.0.3",
-            "decamelize": "^1.1.1",
-            "os-locale": "^1.4.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.1.4",
-            "y18n": "^3.2.0"
+            "camelcase": "2.1.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "string-width": "1.0.2",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
           }
         }
       }
@@ -4874,7 +4874,7 @@
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "requires": {
-        "utila": "~0.3"
+        "utila": "0.3.3"
       },
       "dependencies": {
         "utila": {
@@ -4894,8 +4894,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -4910,7 +4910,7 @@
       "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "requires": {
-        "urijs": "^1.16.1"
+        "urijs": "1.19.1"
       }
     },
     "dom-walk": {
@@ -4933,7 +4933,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
       "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domready": {
@@ -4946,8 +4946,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "dot-prop": {
@@ -4955,7 +4955,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "dotenv": {
@@ -4968,21 +4968,21 @@
       "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
       "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
       "requires": {
-        "caw": "^1.0.1",
-        "concat-stream": "^1.4.7",
-        "each-async": "^1.0.0",
-        "filenamify": "^1.0.1",
-        "got": "^5.0.0",
-        "gulp-decompress": "^1.2.0",
-        "gulp-rename": "^1.2.0",
-        "is-url": "^1.2.0",
-        "object-assign": "^4.0.1",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.2",
-        "stream-combiner2": "^1.1.1",
-        "vinyl": "^1.0.0",
-        "vinyl-fs": "^2.2.0",
-        "ware": "^1.2.0"
+        "caw": "1.2.0",
+        "concat-stream": "1.6.2",
+        "each-async": "1.1.1",
+        "filenamify": "1.2.1",
+        "got": "5.7.1",
+        "gulp-decompress": "1.2.0",
+        "gulp-rename": "1.2.2",
+        "is-url": "1.2.4",
+        "object-assign": "4.1.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.3.6",
+        "stream-combiner2": "1.1.1",
+        "vinyl": "1.2.0",
+        "vinyl-fs": "2.4.4",
+        "ware": "1.3.0"
       },
       "dependencies": {
         "got": {
@@ -4990,21 +4990,21 @@
           "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
           "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
           "requires": {
-            "create-error-class": "^3.0.1",
-            "duplexer2": "^0.1.4",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "node-status-codes": "^1.0.0",
-            "object-assign": "^4.0.1",
-            "parse-json": "^2.1.0",
-            "pinkie-promise": "^2.0.0",
-            "read-all-stream": "^3.0.0",
-            "readable-stream": "^2.0.5",
-            "timed-out": "^3.0.0",
-            "unzip-response": "^1.0.2",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer2": "0.1.4",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "node-status-codes": "1.0.0",
+            "object-assign": "4.1.1",
+            "parse-json": "2.2.0",
+            "pinkie-promise": "2.0.1",
+            "read-all-stream": "3.1.0",
+            "readable-stream": "2.3.6",
+            "timed-out": "3.1.3",
+            "unzip-response": "1.0.2",
+            "url-parse-lax": "1.0.0"
           }
         },
         "timed-out": {
@@ -5029,7 +5029,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "duplexer3": {
@@ -5042,10 +5042,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "e-prime": {
@@ -5059,8 +5059,8 @@
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "requires": {
-        "onetime": "^1.0.0",
-        "set-immediate-shim": "^1.0.0"
+        "onetime": "1.1.0",
+        "set-immediate-shim": "1.0.1"
       },
       "dependencies": {
         "onetime": {
@@ -5076,7 +5076,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "editorconfig": {
@@ -5085,11 +5085,11 @@
       "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.0.5",
-        "commander": "^2.9.0",
-        "lru-cache": "^3.2.0",
-        "semver": "^5.1.0",
-        "sigmund": "^1.0.1"
+        "bluebird": "3.5.1",
+        "commander": "2.9.0",
+        "lru-cache": "3.2.0",
+        "semver": "5.5.0",
+        "sigmund": "1.0.1"
       },
       "dependencies": {
         "lru-cache": {
@@ -5098,7 +5098,7 @@
           "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.1"
+            "pseudomap": "1.0.2"
           }
         }
       }
@@ -5118,13 +5118,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emoji-regex": {
@@ -5147,7 +5147,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.19"
       }
     },
     "end-of-stream": {
@@ -5155,7 +5155,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "engine.io": {
@@ -5163,12 +5163,12 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "ws": "3.3.3"
       },
       "dependencies": {
         "debug": {
@@ -5184,9 +5184,9 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.2",
+            "ultron": "1.1.1"
           }
         }
       }
@@ -5198,14 +5198,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -5222,9 +5222,9 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.2",
+            "ultron": "1.1.1"
           }
         }
       }
@@ -5235,10 +5235,10 @@
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.2"
       }
     },
     "enhanced-resolve": {
@@ -5246,9 +5246,9 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.2.0",
-        "tapable": "^0.1.8"
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.2.0",
+        "tapable": "0.1.10"
       },
       "dependencies": {
         "memory-fs": {
@@ -5279,7 +5279,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -5287,7 +5287,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "error-stack-parser": {
@@ -5295,7 +5295,7 @@
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.1.tgz",
       "integrity": "sha1-oyArj7AxFKqbQKDjZp5IsrZaAQo=",
       "requires": {
-        "stackframe": "^1.0.3"
+        "stackframe": "1.0.4"
       }
     },
     "es-abstract": {
@@ -5304,11 +5304,11 @@
       "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-collections": {
@@ -5317,7 +5317,7 @@
       "integrity": "sha1-+KVHetYpi3mYVGtn2go8X8VypNE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^5.6.17"
+        "babel-runtime": "5.8.38"
       },
       "dependencies": {
         "babel-runtime": {
@@ -5326,7 +5326,7 @@
           "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
           "dev": true,
           "requires": {
-            "core-js": "^1.0.0"
+            "core-js": "1.2.7"
           }
         },
         "core-js": {
@@ -5343,9 +5343,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es5-ext": {
@@ -5353,9 +5353,9 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
       "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -5363,9 +5363,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
@@ -5374,12 +5374,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       }
     },
     "es6-promise": {
@@ -5393,11 +5393,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
@@ -5405,8 +5405,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
       }
     },
     "es6-template-strings": {
@@ -5415,8 +5415,8 @@
       "integrity": "sha1-sWbGpiVi9Hi7d3X2ypYQOlmbSyw=",
       "optional": true,
       "requires": {
-        "es5-ext": "^0.10.12",
-        "esniff": "^1.1"
+        "es5-ext": "0.10.42",
+        "esniff": "1.1.0"
       }
     },
     "es6-weak-map": {
@@ -5425,10 +5425,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-html": {
@@ -5446,10 +5446,10 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.2.0.tgz",
       "integrity": "sha1-Cd55Z3kcyVi3+Jot220jRRrzJ+E=",
       "requires": {
-        "esprima": "~1.0.4",
-        "estraverse": "~1.5.0",
-        "esutils": "~1.0.0",
-        "source-map": "~0.1.30"
+        "esprima": "1.0.4",
+        "estraverse": "1.5.1",
+        "esutils": "1.0.0",
+        "source-map": "0.1.43"
       },
       "dependencies": {
         "esprima": {
@@ -5468,7 +5468,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "optional": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -5479,10 +5479,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       },
       "dependencies": {
         "estraverse": {
@@ -5499,41 +5499,41 @@
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.16.0",
-        "chalk": "^1.1.3",
-        "concat-stream": "^1.5.2",
-        "debug": "^2.1.1",
-        "doctrine": "^2.0.0",
-        "escope": "^3.6.0",
-        "espree": "^3.4.0",
-        "esquery": "^1.0.0",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "glob": "^7.0.3",
-        "globals": "^9.14.0",
-        "ignore": "^3.2.0",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^0.12.0",
-        "is-my-json-valid": "^2.10.0",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.5.1",
-        "json-stable-stringify": "^1.0.0",
-        "levn": "^0.3.0",
-        "lodash": "^4.0.0",
-        "mkdirp": "^0.5.0",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.1",
-        "pluralize": "^1.2.1",
-        "progress": "^1.1.8",
-        "require-uncached": "^1.0.2",
-        "shelljs": "^0.7.5",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "~2.0.1",
-        "table": "^3.7.8",
-        "text-table": "~0.2.0",
-        "user-home": "^2.0.0"
+        "babel-code-frame": "6.26.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "doctrine": "2.1.0",
+        "escope": "3.6.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.1",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.8",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.17.2",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.7.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -5548,7 +5548,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "^1.0.1"
+            "restore-cursor": "1.0.1"
           }
         },
         "estraverse": {
@@ -5563,8 +5563,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "inquirer": {
@@ -5573,19 +5573,19 @@
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^1.1.0",
-            "ansi-regex": "^2.0.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^1.0.1",
-            "cli-width": "^2.0.0",
-            "figures": "^1.3.5",
-            "lodash": "^4.3.0",
-            "readline2": "^1.0.1",
-            "run-async": "^0.1.0",
-            "rx-lite": "^3.1.2",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.0",
-            "through": "^2.3.6"
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.2.0",
+            "figures": "1.7.0",
+            "lodash": "4.17.10",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
           }
         },
         "interpret": {
@@ -5600,7 +5600,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "onetime": {
@@ -5615,8 +5615,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         },
         "run-async": {
@@ -5625,7 +5625,7 @@
           "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
           "dev": true,
           "requires": {
-            "once": "^1.3.0"
+            "once": "1.4.0"
           }
         },
         "rx-lite": {
@@ -5640,9 +5640,9 @@
           "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.0",
-            "interpret": "^1.0.0",
-            "rechoir": "^0.6.2"
+            "glob": "7.1.2",
+            "interpret": "1.1.0",
+            "rechoir": "0.6.2"
           }
         },
         "string-width": {
@@ -5651,9 +5651,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "user-home": {
@@ -5662,7 +5662,7 @@
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0"
+            "os-homedir": "1.0.2"
           }
         }
       }
@@ -5673,7 +5673,7 @@
       "integrity": "sha512-m0q9fiMBzDAIbirlGnpJNWToIhdhJmXXnMG+IFflYzzod9231ZhtmGKegKg8E9T8F1YuVaDSU1FnCm5b9iXVhQ==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^11.3.0"
+        "eslint-config-airbnb-base": "11.3.2"
       }
     },
     "eslint-config-airbnb-base": {
@@ -5682,7 +5682,7 @@
       "integrity": "sha512-/fhjt/VqzBA2SRsx7ErDtv6Ayf+XLw9LIOqmpBuHFCVwyJo2EtzGWMB9fYRFBoWWQLxmNmCpenNiH0RxyeS41w==",
       "dev": true,
       "requires": {
-        "eslint-restricted-globals": "^0.1.1"
+        "eslint-restricted-globals": "0.1.1"
       }
     },
     "eslint-config-prettier": {
@@ -5691,7 +5691,7 @@
       "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
       "dev": true,
       "requires": {
-        "get-stdin": "^5.0.1"
+        "get-stdin": "5.0.1"
       },
       "dependencies": {
         "get-stdin": {
@@ -5708,8 +5708,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "debug": "2.6.9",
+        "resolve": "1.7.1"
       }
     },
     "eslint-module-utils": {
@@ -5718,8 +5718,8 @@
       "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
       }
     },
     "eslint-plugin-import": {
@@ -5728,16 +5728,16 @@
       "integrity": "sha1-Fa7qN6Z0mdhI6OmBgG1GJ7VQOBY=",
       "dev": true,
       "requires": {
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.2.0",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.6.0"
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.2.0",
+        "has": "1.0.1",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.7.1"
       },
       "dependencies": {
         "doctrine": {
@@ -5746,8 +5746,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         },
         "minimatch": {
@@ -5756,7 +5756,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -5767,13 +5767,13 @@
       "integrity": "sha512-5I9SpoP7gT4wBFOtXT8/tXNPYohHBVfyVfO17vkbC7r9kEIxYJF12D3pKqhk8+xnk12rfxKClS3WCFpVckFTPQ==",
       "dev": true,
       "requires": {
-        "aria-query": "^0.7.0",
-        "array-includes": "^3.0.3",
+        "aria-query": "0.7.1",
+        "array-includes": "3.0.3",
         "ast-types-flow": "0.0.7",
-        "axobject-query": "^0.1.0",
-        "damerau-levenshtein": "^1.0.0",
-        "emoji-regex": "^6.1.0",
-        "jsx-ast-utils": "^1.4.0"
+        "axobject-query": "0.1.0",
+        "damerau-levenshtein": "1.0.4",
+        "emoji-regex": "6.1.1",
+        "jsx-ast-utils": "1.4.1"
       }
     },
     "eslint-plugin-react": {
@@ -5782,10 +5782,10 @@
       "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
       "dev": true,
       "requires": {
-        "doctrine": "^2.0.2",
-        "has": "^1.0.1",
-        "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.0"
+        "doctrine": "2.1.0",
+        "has": "1.0.1",
+        "jsx-ast-utils": "2.0.1",
+        "prop-types": "15.6.1"
       },
       "dependencies": {
         "jsx-ast-utils": {
@@ -5794,7 +5794,7 @@
           "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
           "dev": true,
           "requires": {
-            "array-includes": "^3.0.3"
+            "array-includes": "3.0.3"
           }
         }
       }
@@ -5811,8 +5811,8 @@
       "integrity": "sha1-xmhJIp+RRk3t4uDUAgHtar9l8qw=",
       "optional": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.12"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
       }
     },
     "espree": {
@@ -5821,8 +5821,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.5.3",
+        "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -5844,7 +5844,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       },
       "dependencies": {
         "estraverse": {
@@ -5861,7 +5861,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       },
       "dependencies": {
         "estraverse": {
@@ -5923,7 +5923,7 @@
       "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.2.tgz",
       "integrity": "sha1-n3EDKEwQWmbfQDCysycxZYNwE9o=",
       "requires": {
-        "require-like": ">= 0.1.1"
+        "require-like": "0.1.2"
       }
     },
     "eve": {
@@ -5937,8 +5937,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
       }
     },
     "eventemitter3": {
@@ -5956,7 +5956,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "requires": {
-        "original": ">=0.0.5"
+        "original": "1.0.0"
       }
     },
     "evp_bytestokey": {
@@ -5964,8 +5964,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.2"
       }
     },
     "exec-buffer": {
@@ -5973,11 +5973,11 @@
       "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
       "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
       "requires": {
-        "execa": "^0.7.0",
-        "p-finally": "^1.0.0",
-        "pify": "^3.0.0",
-        "rimraf": "^2.5.4",
-        "tempfile": "^2.0.0"
+        "execa": "0.7.0",
+        "p-finally": "1.0.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2",
+        "tempfile": "2.0.0"
       },
       "dependencies": {
         "execa": {
@@ -5985,13 +5985,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         }
       }
@@ -6001,8 +6001,8 @@
       "resolved": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz",
       "integrity": "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=",
       "requires": {
-        "async-each-series": "^1.1.0",
-        "object-assign": "^4.1.0"
+        "async-each-series": "1.1.0",
+        "object-assign": "4.1.1"
       }
     },
     "exec-sh": {
@@ -6011,7 +6011,7 @@
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "optional": true,
       "requires": {
-        "merge": "^1.1.3"
+        "merge": "1.2.0"
       }
     },
     "execa": {
@@ -6019,13 +6019,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
       "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "execall": {
@@ -6034,7 +6034,7 @@
       "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
       "dev": true,
       "requires": {
-        "clone-regexp": "^1.0.0"
+        "clone-regexp": "1.0.1"
       }
     },
     "executable": {
@@ -6042,7 +6042,7 @@
       "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
       "integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
       "requires": {
-        "meow": "^3.1.0"
+        "meow": "3.7.0"
       }
     },
     "exenv": {
@@ -6066,7 +6066,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -6074,7 +6074,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       }
     },
     "expand-template": {
@@ -6087,7 +6087,7 @@
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "requires": {
-        "os-homedir": "^1.0.1"
+        "os-homedir": "1.0.2"
       }
     },
     "express": {
@@ -6095,36 +6095,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.3",
+        "proxy-addr": "2.0.3",
         "qs": "6.5.1",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -6139,10 +6139,10 @@
       "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.6.12.tgz",
       "integrity": "sha512-ouLWV0hRw4hnaLtXzzwhdC79ewxKbY2PRvm05mPc/zOH5W5WVCHDQ1SmNxEPBQdUeeSNh29aIqW9zEQkA3kMuA==",
       "requires": {
-        "accepts": "^1.3.0",
-        "content-type": "^1.0.4",
-        "http-errors": "^1.3.0",
-        "raw-body": "^2.3.2"
+        "accepts": "1.3.5",
+        "content-type": "1.0.4",
+        "http-errors": "1.6.3",
+        "raw-body": "2.3.2"
       }
     },
     "extend": {
@@ -6155,8 +6155,8 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -6164,7 +6164,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -6174,9 +6174,9 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
       },
       "dependencies": {
         "tmp": {
@@ -6184,7 +6184,7 @@
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "requires": {
-            "os-tmpdir": "~1.0.2"
+            "os-tmpdir": "1.0.2"
           }
         }
       }
@@ -6194,7 +6194,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extract-text-webpack-plugin": {
@@ -6202,9 +6202,9 @@
       "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz",
       "integrity": "sha1-yVvzy6rEnclvHcbgclSfu2VMzSw=",
       "requires": {
-        "async": "^1.5.0",
-        "loader-utils": "^0.2.3",
-        "webpack-sources": "^0.1.0"
+        "async": "1.5.2",
+        "loader-utils": "0.2.17",
+        "webpack-sources": "0.1.5"
       },
       "dependencies": {
         "async": {
@@ -6224,9 +6224,9 @@
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
       },
       "dependencies": {
         "time-stamp": {
@@ -6246,10 +6246,10 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-1.0.1.tgz",
       "integrity": "sha512-C2VHbdBwSkaQDyavjQZDflZzmZKrsUK3fTdJtsOnED0L0vtHCw+NL0h8pRcydbpRHlNJLZ4/LbOfEdJKspK91A==",
       "requires": {
-        "bash-glob": "^1.0.1",
-        "glob-parent": "^3.1.0",
-        "micromatch": "^3.0.3",
-        "readdir-enhanced": "^1.5.2"
+        "bash-glob": "1.0.2",
+        "glob-parent": "3.1.0",
+        "micromatch": "3.1.10",
+        "readdir-enhanced": "1.5.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -6267,16 +6267,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -6284,7 +6284,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -6294,13 +6294,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -6308,7 +6308,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -6316,7 +6316,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -6324,7 +6324,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -6332,7 +6332,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -6342,7 +6342,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -6350,7 +6350,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -6360,9 +6360,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -6377,14 +6377,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -6392,7 +6392,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -6400,7 +6400,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -6410,10 +6410,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -6421,7 +6421,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -6431,8 +6431,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -6440,7 +6440,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -6448,7 +6448,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -6456,9 +6456,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -6471,7 +6471,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -6479,7 +6479,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6487,7 +6487,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -6507,19 +6507,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -6545,7 +6545,7 @@
       "integrity": "sha512-o2eo/X2syzzERAtN5LcGbiVQ0WwZSlN3qLtadwAz3X8Bu+XWD16dja/KMsjZLiQr+BLGPDnHGkc4yUJf1Xpkpw==",
       "dev": true,
       "requires": {
-        "format": "^0.2.2"
+        "format": "0.2.2"
       }
     },
     "faye-websocket": {
@@ -6553,7 +6553,7 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
       "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "fb-watchman": {
@@ -6561,7 +6561,7 @@
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.0.0"
       }
     },
     "fbjs": {
@@ -6569,13 +6569,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.18"
       },
       "dependencies": {
         "core-js": {
@@ -6590,7 +6590,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -6598,7 +6598,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -6607,8 +6607,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "file-loader": {
@@ -6616,7 +6616,7 @@
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.9.0.tgz",
       "integrity": "sha1-HS2t3UJM5tGwfP4/eXMb7TYXq0I=",
       "requires": {
-        "loader-utils": "~0.2.5"
+        "loader-utils": "0.2.17"
       }
     },
     "file-type": {
@@ -6639,9 +6639,9 @@
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
       "requires": {
-        "filename-reserved-regex": "^1.0.0",
-        "strip-outer": "^1.0.0",
-        "trim-repeated": "^1.0.0"
+        "filename-reserved-regex": "1.0.0",
+        "strip-outer": "1.0.1",
+        "trim-repeated": "1.0.0"
       }
     },
     "filesize": {
@@ -6654,11 +6654,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.0.0",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "finalhandler": {
@@ -6667,12 +6667,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       }
     },
     "find-cache-dir": {
@@ -6680,9 +6680,9 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
       "requires": {
-        "commondir": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pkg-dir": "^1.0.0"
+        "commondir": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pkg-dir": "1.0.0"
       }
     },
     "find-index": {
@@ -6697,7 +6697,7 @@
       "integrity": "sha1-tt6zzMtpnIcDdne87eLF9YYrJVA=",
       "requires": {
         "findup-sync": "0.4.2",
-        "merge": "^1.2.0"
+        "merge": "1.2.0"
       },
       "dependencies": {
         "detect-file": {
@@ -6705,7 +6705,7 @@
           "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
           "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
           "requires": {
-            "fs-exists-sync": "^0.1.0"
+            "fs-exists-sync": "0.1.0"
           }
         },
         "findup-sync": {
@@ -6713,10 +6713,10 @@
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
           "integrity": "sha1-qBF9D3MST1pFRoOVef5S1xKfteU=",
           "requires": {
-            "detect-file": "^0.1.0",
-            "is-glob": "^2.0.1",
-            "micromatch": "^2.3.7",
-            "resolve-dir": "^0.1.0"
+            "detect-file": "0.1.0",
+            "is-glob": "2.0.1",
+            "micromatch": "2.3.11",
+            "resolve-dir": "0.1.1"
           }
         },
         "global-modules": {
@@ -6724,8 +6724,8 @@
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
           "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
           "requires": {
-            "global-prefix": "^0.1.4",
-            "is-windows": "^0.2.0"
+            "global-prefix": "0.1.5",
+            "is-windows": "0.2.0"
           }
         },
         "global-prefix": {
@@ -6733,10 +6733,10 @@
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
           "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
           "requires": {
-            "homedir-polyfill": "^1.0.0",
-            "ini": "^1.3.4",
-            "is-windows": "^0.2.0",
-            "which": "^1.2.12"
+            "homedir-polyfill": "1.0.1",
+            "ini": "1.3.5",
+            "is-windows": "0.2.0",
+            "which": "1.3.0"
           }
         },
         "is-windows": {
@@ -6749,8 +6749,8 @@
           "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
           "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
           "requires": {
-            "expand-tilde": "^1.2.2",
-            "global-modules": "^0.2.3"
+            "expand-tilde": "1.2.2",
+            "global-modules": "0.2.3"
           }
         }
       }
@@ -6760,8 +6760,8 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "path-exists": {
@@ -6769,7 +6769,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         }
       }
@@ -6779,10 +6779,10 @@
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
       "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
       "requires": {
-        "array-uniq": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "meow": "^3.5.0",
-        "semver-regex": "^1.0.0"
+        "array-uniq": "1.0.3",
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0",
+        "semver-regex": "1.0.0"
       }
     },
     "findup-sync": {
@@ -6790,10 +6790,10 @@
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -6811,16 +6811,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -6828,7 +6828,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -6838,13 +6838,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -6852,7 +6852,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -6860,7 +6860,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -6868,7 +6868,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -6876,7 +6876,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -6886,7 +6886,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -6894,7 +6894,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -6904,9 +6904,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -6921,14 +6921,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -6936,7 +6936,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -6944,7 +6944,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -6954,10 +6954,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -6965,7 +6965,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -6975,7 +6975,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -6983,7 +6983,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -6991,9 +6991,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -7006,7 +7006,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -7014,7 +7014,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7022,7 +7022,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7042,19 +7042,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -7064,11 +7064,11 @@
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       },
       "dependencies": {
         "expand-tilde": {
@@ -7076,7 +7076,7 @@
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.1"
           }
         }
       }
@@ -7096,7 +7096,7 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",
       "integrity": "sha1-cOKRiKdL4MPIlAnu0fqVd5B64y8=",
       "requires": {
-        "is-buffer": "~1.1.2"
+        "is-buffer": "1.1.6"
       }
     },
     "flat-cache": {
@@ -7105,10 +7105,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       },
       "dependencies": {
         "del": {
@@ -7117,13 +7117,13 @@
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
           "dev": true,
           "requires": {
-            "globby": "^5.0.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "rimraf": "^2.2.8"
+            "globby": "5.0.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.2"
           }
         },
         "globby": {
@@ -7132,12 +7132,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -7164,7 +7164,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
       "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -7182,7 +7182,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "requires": {
-        "is-function": "~1.0.0"
+        "is-function": "1.0.1"
       }
     },
     "for-in": {
@@ -7195,7 +7195,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -7213,9 +7213,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "format": {
@@ -7234,7 +7234,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -7247,9 +7247,9 @@
       "resolved": "https://registry.npmjs.org/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0.tgz",
       "integrity": "sha512-K27M3VK30wVoOarP651zDmb93R9zF28usW4ocaK3mfQeIEI5BPht/EzZs5E8QLLwbLRJQMwscAjDxYPb1FuNiw==",
       "requires": {
-        "chalk": "^1.1.3",
-        "error-stack-parser": "^2.0.0",
-        "string-width": "^2.0.0"
+        "chalk": "1.1.3",
+        "error-stack-parser": "2.0.1",
+        "string-width": "2.1.1"
       }
     },
     "front-matter": {
@@ -7257,7 +7257,7 @@
       "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.3.0.tgz",
       "integrity": "sha1-cgOviWzjV+4E4qpFFp6pHtf2dQQ=",
       "requires": {
-        "js-yaml": "^3.10.0"
+        "js-yaml": "3.11.0"
       },
       "dependencies": {
         "esprima": {
@@ -7270,8 +7270,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
           "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
           }
         }
       }
@@ -7296,9 +7296,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
       "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
       }
     },
     "fs-minipass": {
@@ -7306,7 +7306,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.0"
       }
     },
     "fs-readdir-recursive": {
@@ -7325,8 +7325,8 @@
       "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.9.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.9.1"
       },
       "dependencies": {
         "abbrev": {
@@ -7348,8 +7348,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -7360,7 +7360,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -7414,7 +7414,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -7427,14 +7427,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -7442,12 +7442,12 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -7460,7 +7460,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -7468,7 +7468,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -7476,8 +7476,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -7493,7 +7493,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -7505,7 +7505,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -7516,8 +7516,8 @@
           "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -7525,7 +7525,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -7545,9 +7545,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -7555,16 +7555,16 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.6",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -7572,8 +7572,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -7586,8 +7586,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -7595,10 +7595,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -7614,7 +7614,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -7632,8 +7632,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -7651,10 +7651,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -7669,13 +7669,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -7683,7 +7683,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -7719,9 +7719,9 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -7729,14 +7729,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -7749,13 +7749,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -7768,7 +7768,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -7797,115 +7797,115 @@
       "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-1.9.260.tgz",
       "integrity": "sha1-Nl0sZzhGUR3vclBIipVKilVN0WE=",
       "requires": {
-        "async": "^2.1.2",
-        "babel-code-frame": "^6.22.0",
-        "babel-core": "^6.24.1",
-        "babel-loader": "^6.0.0",
-        "babel-plugin-add-module-exports": "^0.2.1",
-        "babel-plugin-transform-object-assign": "^6.8.0",
-        "babel-polyfill": "^6.23.0",
-        "babel-preset-env": "^1.6.0",
-        "babel-preset-es2015": "^6.24.1",
-        "babel-preset-react": "^6.24.1",
-        "babel-preset-stage-0": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.24.1",
-        "babylon": "^6.17.3",
-        "better-queue": "^3.8.6",
-        "bluebird": "^3.5.0",
-        "chalk": "^1.1.3",
-        "chokidar": "^1.7.0",
+        "async": "2.6.0",
+        "babel-code-frame": "6.26.0",
+        "babel-core": "6.26.3",
+        "babel-loader": "6.4.1",
+        "babel-plugin-add-module-exports": "0.2.1",
+        "babel-plugin-transform-object-assign": "6.22.0",
+        "babel-polyfill": "6.26.0",
+        "babel-preset-env": "1.7.0",
+        "babel-preset-es2015": "6.24.1",
+        "babel-preset-react": "6.24.1",
+        "babel-preset-stage-0": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babylon": "6.18.0",
+        "better-queue": "3.8.7",
+        "bluebird": "3.5.1",
+        "chalk": "1.1.3",
+        "chokidar": "1.7.0",
         "chunk-manifest-webpack-plugin": "0.1.0",
-        "common-tags": "^1.4.0",
-        "convert-hrtime": "^2.0.0",
-        "copyfiles": "^1.2.0",
-        "core-js": "^2.5.0",
-        "css-loader": "^0.26.1",
-        "debug": "^2.6.0",
-        "del": "^3.0.0",
-        "detect-port": "^1.2.1",
-        "devcert-san": "^0.3.3",
-        "domready": "^1.0.8",
-        "dotenv": "^4.0.0",
-        "express": "^4.14.0",
-        "express-graphql": "^0.6.6",
-        "fast-levenshtein": "~2.0.4",
-        "file-loader": "^0.9.0",
-        "flat": "^2.0.1",
-        "friendly-errors-webpack-plugin": "^1.6.1",
-        "front-matter": "^2.1.0",
-        "fs-extra": "^4.0.1",
-        "gatsby-1-config-css-modules": "^1.0.11",
-        "gatsby-1-config-extract-plugin": "^1.0.3",
-        "gatsby-cli": "^1.1.52",
-        "gatsby-link": "^1.6.44",
-        "gatsby-module-loader": "^1.0.11",
-        "gatsby-react-router-scroll": "^1.0.17",
-        "glob": "^7.1.1",
-        "graphql": "^0.11.7",
-        "graphql-relay": "^0.5.1",
-        "graphql-skip-limit": "^1.0.11",
-        "history": "^4.6.2",
-        "invariant": "^2.2.2",
-        "is-relative": "^0.2.1",
-        "is-relative-url": "^2.0.0",
-        "joi": "12.x.x",
-        "json-loader": "^0.5.2",
-        "json-stringify-safe": "^5.0.1",
-        "json5": "^0.5.0",
-        "lodash": "^4.17.4",
-        "lodash-id": "^0.14.0",
-        "lowdb": "^0.16.2",
-        "md5": "^2.2.1",
-        "md5-file": "^3.1.1",
-        "mime": "^1.3.6",
-        "mitt": "^1.1.2",
-        "mkdirp": "^0.5.1",
-        "moment": "^2.16.0",
-        "node-libs-browser": "^2.0.0",
-        "normalize-path": "^2.1.1",
-        "null-loader": "^0.1.1",
-        "opn": "^5.1.0",
-        "parse-filepath": "^1.0.1",
-        "path-exists": "^3.0.0",
-        "postcss-browser-reporter": "^0.5.0",
-        "postcss-cssnext": "^2.8.0",
-        "postcss-import": "^8.2.0",
-        "postcss-loader": "^0.13.0",
-        "postcss-reporter": "^1.4.1",
-        "raw-loader": "^0.5.1",
-        "react": "^15.6.0",
-        "react-dev-utils": "^4.2.1",
-        "react-dom": "^15.6.0",
-        "react-error-overlay": "^3.0.0",
-        "react-hot-loader": "^3.0.0-beta.6",
-        "react-router": "^4.1.1",
-        "react-router-dom": "^4.1.1",
-        "redux": "^3.6.0",
+        "common-tags": "1.7.2",
+        "convert-hrtime": "2.0.0",
+        "copyfiles": "1.2.0",
+        "core-js": "2.5.6",
+        "css-loader": "0.26.4",
+        "debug": "2.6.9",
+        "del": "3.0.0",
+        "detect-port": "1.2.2",
+        "devcert-san": "0.3.3",
+        "domready": "1.0.8",
+        "dotenv": "4.0.0",
+        "express": "4.16.3",
+        "express-graphql": "0.6.12",
+        "fast-levenshtein": "2.0.6",
+        "file-loader": "0.9.0",
+        "flat": "2.0.1",
+        "friendly-errors-webpack-plugin": "1.7.0",
+        "front-matter": "2.3.0",
+        "fs-extra": "4.0.3",
+        "gatsby-1-config-css-modules": "1.0.11",
+        "gatsby-1-config-extract-plugin": "1.0.3",
+        "gatsby-cli": "1.1.52",
+        "gatsby-link": "1.6.44",
+        "gatsby-module-loader": "1.0.11",
+        "gatsby-react-router-scroll": "1.0.17",
+        "glob": "7.1.2",
+        "graphql": "0.11.7",
+        "graphql-relay": "0.5.5",
+        "graphql-skip-limit": "1.0.11",
+        "history": "4.7.2",
+        "invariant": "2.2.4",
+        "is-relative": "0.2.1",
+        "is-relative-url": "2.0.0",
+        "joi": "12.0.0",
+        "json-loader": "0.5.7",
+        "json-stringify-safe": "5.0.1",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "lodash-id": "0.14.0",
+        "lowdb": "0.16.2",
+        "md5": "2.2.1",
+        "md5-file": "3.2.3",
+        "mime": "1.6.0",
+        "mitt": "1.1.3",
+        "mkdirp": "0.5.1",
+        "moment": "2.22.1",
+        "node-libs-browser": "2.1.0",
+        "normalize-path": "2.1.1",
+        "null-loader": "0.1.1",
+        "opn": "5.3.0",
+        "parse-filepath": "1.0.2",
+        "path-exists": "3.0.0",
+        "postcss-browser-reporter": "0.5.0",
+        "postcss-cssnext": "2.11.0",
+        "postcss-import": "8.2.0",
+        "postcss-loader": "0.13.0",
+        "postcss-reporter": "1.4.1",
+        "raw-loader": "0.5.1",
+        "react": "15.6.2",
+        "react-dev-utils": "4.2.1",
+        "react-dom": "15.6.2",
+        "react-error-overlay": "3.0.0",
+        "react-hot-loader": "3.1.3",
+        "react-router": "4.2.0",
+        "react-router-dom": "4.2.2",
+        "redux": "3.7.2",
         "relay-compiler": "1.4.1",
-        "remote-redux-devtools": "^0.5.7",
-        "serve": "^6.4.0",
-        "shallow-compare": "^1.2.2",
-        "sift": "^3.2.6",
-        "signal-exit": "^3.0.2",
-        "slash": "^1.0.0",
-        "socket.io": "^2.0.3",
-        "static-site-generator-webpack-plugin": "^3.4.1",
-        "string-similarity": "^1.2.0",
-        "style-loader": "^0.13.0",
-        "type-of": "^2.0.1",
-        "url-loader": "^0.6.2",
-        "uuid": "^3.1.0",
-        "v8-compile-cache": "^1.1.0",
-        "webpack": "^1.13.3",
-        "webpack-configurator": "^0.3.0",
-        "webpack-dev-middleware": "^1.8.4",
-        "webpack-dev-server": "^1.16.1",
-        "webpack-hot-middleware": "^2.13.2",
+        "remote-redux-devtools": "0.5.12",
+        "serve": "6.5.6",
+        "shallow-compare": "1.2.2",
+        "sift": "3.3.12",
+        "signal-exit": "3.0.2",
+        "slash": "1.0.0",
+        "socket.io": "2.1.0",
+        "static-site-generator-webpack-plugin": "3.4.1",
+        "string-similarity": "1.2.0",
+        "style-loader": "0.13.2",
+        "type-of": "2.0.1",
+        "url-loader": "0.6.2",
+        "uuid": "3.2.1",
+        "v8-compile-cache": "1.1.2",
+        "webpack": "1.15.0",
+        "webpack-configurator": "0.3.1",
+        "webpack-dev-middleware": "1.12.2",
+        "webpack-dev-server": "1.16.5",
+        "webpack-hot-middleware": "2.22.1",
         "webpack-md5-hash": "0.0.5",
-        "webpack-stats-plugin": "^0.1.4",
-        "webpack-validator": "^2.2.7",
-        "yaml-loader": "^0.4.0"
+        "webpack-stats-plugin": "0.1.5",
+        "webpack-validator": "2.3.0",
+        "yaml-loader": "0.4.0"
       },
       "dependencies": {
         "gatsby-cli": {
@@ -7913,23 +7913,23 @@
           "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-1.1.52.tgz",
           "integrity": "sha1-G7CWcbd0pJIC6lu5CqSb/uuqL8M=",
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "bluebird": "^3.5.0",
-            "common-tags": "^1.4.0",
-            "convert-hrtime": "^2.0.0",
-            "core-js": "^2.5.0",
-            "execa": "^0.8.0",
-            "fs-extra": "^4.0.1",
-            "hosted-git-info": "^2.5.0",
-            "lodash": "^4.17.4",
-            "pretty-error": "^2.1.1",
-            "resolve-cwd": "^2.0.0",
-            "source-map": "^0.5.7",
-            "stack-trace": "^0.0.10",
-            "update-notifier": "^2.3.0",
-            "yargs": "^11.1.0",
-            "yurnalist": "^0.2.1"
+            "babel-code-frame": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "bluebird": "3.5.1",
+            "common-tags": "1.7.2",
+            "convert-hrtime": "2.0.0",
+            "core-js": "2.5.6",
+            "execa": "0.8.0",
+            "fs-extra": "4.0.3",
+            "hosted-git-info": "2.6.0",
+            "lodash": "4.17.10",
+            "pretty-error": "2.1.1",
+            "resolve-cwd": "2.0.0",
+            "source-map": "0.5.7",
+            "stack-trace": "0.0.10",
+            "update-notifier": "2.5.0",
+            "yargs": "11.1.0",
+            "yurnalist": "0.2.1"
           }
         }
       }
@@ -7939,7 +7939,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-1-config-css-modules/-/gatsby-1-config-css-modules-1.0.11.tgz",
       "integrity": "sha1-WhAsaxH5ppY7OJLsyVlRHhaI5SU=",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "gatsby-1-config-extract-plugin": {
@@ -7947,8 +7947,8 @@
       "resolved": "https://registry.npmjs.org/gatsby-1-config-extract-plugin/-/gatsby-1-config-extract-plugin-1.0.3.tgz",
       "integrity": "sha1-niyWLUVjyV+inag+PZMBcSmvARU=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "extract-text-webpack-plugin": "^1.0.1"
+        "babel-runtime": "6.26.0",
+        "extract-text-webpack-plugin": "1.0.1"
       }
     },
     "gatsby-link": {
@@ -7956,11 +7956,11 @@
       "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-1.6.44.tgz",
       "integrity": "sha1-MZEuZtOyFjLOJ+W3MQ7IjZp16sM=",
       "requires": {
-        "@types/history": "^4.6.2",
-        "@types/react-router-dom": "^4.2.2",
-        "babel-runtime": "^6.26.0",
-        "prop-types": "^15.5.8",
-        "ric": "^1.3.0"
+        "@types/history": "4.6.2",
+        "@types/react-router-dom": "4.2.6",
+        "babel-runtime": "6.26.0",
+        "prop-types": "15.6.1",
+        "ric": "1.3.0"
       }
     },
     "gatsby-module-loader": {
@@ -7968,8 +7968,8 @@
       "resolved": "https://registry.npmjs.org/gatsby-module-loader/-/gatsby-module-loader-1.0.11.tgz",
       "integrity": "sha1-NfJpRW9qbYXGk73Cs7OzQymH9Vs=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "loader-utils": "^0.2.16"
+        "babel-runtime": "6.26.0",
+        "loader-utils": "0.2.17"
       }
     },
     "gatsby-plugin-catch-links": {
@@ -7977,7 +7977,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-1.0.22.tgz",
       "integrity": "sha1-pR9SWvzfmhBQ4oT5P3L8M2lMl4k=",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "gatsby-plugin-feed": {
@@ -7985,10 +7985,10 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-1.3.22.tgz",
       "integrity": "sha1-sOnLu0QooxulfEmMNt2IMJoJW30=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "lodash.merge": "^4.6.0",
-        "pify": "^3.0.0",
-        "rss": "^1.2.2"
+        "babel-runtime": "6.26.0",
+        "lodash.merge": "4.6.1",
+        "pify": "3.0.0",
+        "rss": "1.2.2"
       }
     },
     "gatsby-plugin-google-analytics": {
@@ -7996,7 +7996,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-1.0.31.tgz",
       "integrity": "sha1-6vFuGAlGGxC63xLAUDjEKXRXg8A=",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "gatsby-plugin-google-fonts": {
@@ -8009,9 +8009,9 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-1.0.21.tgz",
       "integrity": "sha1-jIduU68j8jrWWC/U7Ok+jXh1Q10=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.5.0",
-        "sharp": "^0.20.1"
+        "babel-runtime": "6.26.0",
+        "bluebird": "3.5.1",
+        "sharp": "0.20.2"
       }
     },
     "gatsby-plugin-nprogress": {
@@ -8019,8 +8019,8 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-nprogress/-/gatsby-plugin-nprogress-1.0.14.tgz",
       "integrity": "sha1-V2+S4GWPHcZuURuZ/07+c4m/zFc=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "nprogress": "^0.2.0"
+        "babel-runtime": "6.26.0",
+        "nprogress": "0.2.0"
       }
     },
     "gatsby-plugin-offline": {
@@ -8028,8 +8028,8 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-1.0.16.tgz",
       "integrity": "sha1-07kqncQnyssQbd3zNr2mhFbqgSY=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "sw-precache": "^5.0.0"
+        "babel-runtime": "6.26.0",
+        "sw-precache": "5.2.1"
       }
     },
     "gatsby-plugin-react-helmet": {
@@ -8037,8 +8037,8 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-1.0.8.tgz",
       "integrity": "sha512-kkt+uvbu/fxb55z7URH6YBXGc2I80myannVPMmv0Mmrr3Ennmm4uTgrgTiTrkasyFN0AKGlXRuuHa2/zrc1TXA==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "react-helmet": "^5.1.3"
+        "babel-runtime": "6.26.0",
+        "react-helmet": "5.2.0"
       }
     },
     "gatsby-plugin-segment-js": {
@@ -8046,7 +8046,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-segment-js/-/gatsby-plugin-segment-js-1.1.2.tgz",
       "integrity": "sha512-6uULRrOkoW96YWSzQXxsHnpdGngivFMjkh7fByPRX+iLHp6SsKzU9eE1qjQlsQQEcdUsyf/BtXCdo5AmVhbmzA==",
       "requires": {
-        "npm": "^5.7.1"
+        "npm": "5.8.0"
       },
       "dependencies": {
         "npm": {
@@ -8054,123 +8054,123 @@
           "resolved": "https://registry.npmjs.org/npm/-/npm-5.8.0.tgz",
           "integrity": "sha512-DowXzQwtSWDtbAjuWecuEiismR0VdNEYaL3VxNTYTdW6AGkYxfGk9LUZ/rt6etEyiH4IEk95HkJeGfXE5Rz9xQ==",
           "requires": {
-            "JSONStream": "^1.3.2",
-            "abbrev": "~1.1.1",
-            "ansi-regex": "~3.0.0",
-            "ansicolors": "~0.3.2",
-            "ansistyles": "~0.1.3",
-            "aproba": "~1.2.0",
-            "archy": "~1.0.0",
-            "bin-links": "^1.1.0",
-            "bluebird": "~3.5.1",
-            "cacache": "^10.0.4",
-            "call-limit": "~1.1.0",
-            "chownr": "~1.0.1",
-            "cli-table2": "~0.2.0",
-            "cmd-shim": "~2.0.2",
-            "columnify": "~1.5.4",
-            "config-chain": "~1.1.11",
-            "debuglog": "*",
-            "detect-indent": "~5.0.0",
-            "detect-newline": "^2.1.0",
-            "dezalgo": "~1.0.3",
-            "editor": "~1.0.0",
-            "find-npm-prefix": "^1.0.2",
-            "fs-vacuum": "~1.2.10",
-            "fs-write-stream-atomic": "~1.0.10",
-            "gentle-fs": "^2.0.1",
-            "glob": "~7.1.2",
-            "graceful-fs": "~4.1.11",
-            "has-unicode": "~2.0.1",
-            "hosted-git-info": "^2.6.0",
-            "iferr": "~0.1.5",
-            "imurmurhash": "*",
-            "inflight": "~1.0.6",
-            "inherits": "~2.0.3",
-            "ini": "^1.3.5",
-            "init-package-json": "^1.10.3",
-            "is-cidr": "~1.0.0",
-            "json-parse-better-errors": "^1.0.1",
-            "lazy-property": "~1.0.0",
-            "libcipm": "^1.6.0",
-            "libnpx": "^10.0.1",
-            "lockfile": "~1.0.3",
-            "lodash._baseindexof": "*",
-            "lodash._baseuniq": "~4.6.0",
-            "lodash._bindcallback": "*",
-            "lodash._cacheindexof": "*",
-            "lodash._createcache": "*",
-            "lodash._getnative": "*",
-            "lodash.clonedeep": "~4.5.0",
-            "lodash.restparam": "*",
-            "lodash.union": "~4.6.0",
-            "lodash.uniq": "~4.5.0",
-            "lodash.without": "~4.4.0",
-            "lru-cache": "~4.1.1",
-            "meant": "~1.0.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "~0.5.1",
-            "move-concurrently": "^1.0.1",
-            "nopt": "~4.0.1",
-            "normalize-package-data": "~2.4.0",
-            "npm-cache-filename": "~1.0.2",
-            "npm-install-checks": "~3.0.0",
-            "npm-lifecycle": "^2.0.1",
-            "npm-package-arg": "~6.0.0",
-            "npm-packlist": "~1.1.10",
-            "npm-profile": "^3.0.1",
-            "npm-registry-client": "^8.5.1",
-            "npm-user-validate": "~1.0.0",
-            "npmlog": "~4.1.2",
-            "once": "~1.4.0",
-            "opener": "~1.4.3",
-            "osenv": "^0.1.5",
-            "pacote": "^7.6.1",
-            "path-is-inside": "~1.0.2",
-            "promise-inflight": "~1.0.1",
-            "qrcode-terminal": "~0.11.0",
-            "query-string": "^5.1.0",
-            "qw": "~1.0.1",
-            "read": "~1.0.7",
-            "read-cmd-shim": "~1.0.1",
-            "read-installed": "~4.0.3",
-            "read-package-json": "^2.0.13",
-            "read-package-tree": "~5.1.6",
-            "readable-stream": "^2.3.5",
-            "readdir-scoped-modules": "*",
-            "request": "~2.83.0",
-            "retry": "~0.10.1",
-            "rimraf": "~2.6.2",
-            "safe-buffer": "~5.1.1",
-            "semver": "^5.5.0",
-            "sha": "~2.0.1",
-            "slide": "~1.1.6",
-            "sorted-object": "~2.0.1",
-            "sorted-union-stream": "~2.1.3",
-            "ssri": "^5.2.4",
-            "strip-ansi": "~4.0.0",
-            "tar": "^4.4.0",
-            "text-table": "~0.2.0",
+            "JSONStream": "1.3.2",
+            "abbrev": "1.1.1",
+            "ansi-regex": "3.0.0",
+            "ansicolors": "0.3.2",
+            "ansistyles": "0.1.3",
+            "aproba": "1.2.0",
+            "archy": "1.0.0",
+            "bin-links": "1.1.0",
+            "bluebird": "3.5.1",
+            "cacache": "10.0.4",
+            "call-limit": "1.1.0",
+            "chownr": "1.0.1",
+            "cli-table2": "0.2.0",
+            "cmd-shim": "2.0.2",
+            "columnify": "1.5.4",
+            "config-chain": "1.1.11",
+            "debuglog": "1.0.1",
+            "detect-indent": "5.0.0",
+            "detect-newline": "2.1.0",
+            "dezalgo": "1.0.3",
+            "editor": "1.0.0",
+            "find-npm-prefix": "1.0.2",
+            "fs-vacuum": "1.2.10",
+            "fs-write-stream-atomic": "1.0.10",
+            "gentle-fs": "2.0.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "has-unicode": "2.0.1",
+            "hosted-git-info": "2.6.0",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "ini": "1.3.5",
+            "init-package-json": "1.10.3",
+            "is-cidr": "1.0.0",
+            "json-parse-better-errors": "1.0.1",
+            "lazy-property": "1.0.0",
+            "libcipm": "1.6.0",
+            "libnpx": "10.0.1",
+            "lockfile": "1.0.3",
+            "lodash._baseindexof": "3.1.0",
+            "lodash._baseuniq": "4.6.0",
+            "lodash._bindcallback": "3.0.1",
+            "lodash._cacheindexof": "3.0.2",
+            "lodash._createcache": "3.1.2",
+            "lodash._getnative": "3.9.1",
+            "lodash.clonedeep": "4.5.0",
+            "lodash.restparam": "3.6.1",
+            "lodash.union": "4.6.0",
+            "lodash.uniq": "4.5.0",
+            "lodash.without": "4.4.0",
+            "lru-cache": "4.1.1",
+            "meant": "1.0.1",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "nopt": "4.0.1",
+            "normalize-package-data": "2.4.0",
+            "npm-cache-filename": "1.0.2",
+            "npm-install-checks": "3.0.0",
+            "npm-lifecycle": "2.0.1",
+            "npm-package-arg": "6.0.0",
+            "npm-packlist": "1.1.10",
+            "npm-profile": "3.0.1",
+            "npm-registry-client": "8.5.1",
+            "npm-user-validate": "1.0.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "opener": "1.4.3",
+            "osenv": "0.1.5",
+            "pacote": "7.6.1",
+            "path-is-inside": "1.0.2",
+            "promise-inflight": "1.0.1",
+            "qrcode-terminal": "0.11.0",
+            "query-string": "5.1.0",
+            "qw": "1.0.1",
+            "read": "1.0.7",
+            "read-cmd-shim": "1.0.1",
+            "read-installed": "4.0.3",
+            "read-package-json": "2.0.13",
+            "read-package-tree": "5.1.6",
+            "readable-stream": "2.3.5",
+            "readdir-scoped-modules": "1.0.2",
+            "request": "2.83.0",
+            "retry": "0.10.1",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.1",
+            "semver": "5.5.0",
+            "sha": "2.0.1",
+            "slide": "1.1.6",
+            "sorted-object": "2.0.1",
+            "sorted-union-stream": "2.1.3",
+            "ssri": "5.2.4",
+            "strip-ansi": "4.0.0",
+            "tar": "4.4.0",
+            "text-table": "0.2.0",
             "uid-number": "0.0.6",
-            "umask": "~1.1.0",
-            "unique-filename": "~1.1.0",
-            "unpipe": "~1.0.0",
-            "update-notifier": "~2.3.0",
-            "uuid": "^3.2.1",
-            "validate-npm-package-license": "*",
-            "validate-npm-package-name": "~3.0.0",
-            "which": "~1.3.0",
-            "worker-farm": "^1.5.4",
-            "wrappy": "~1.0.2",
-            "write-file-atomic": "^2.3.0"
+            "umask": "1.1.0",
+            "unique-filename": "1.1.0",
+            "unpipe": "1.0.0",
+            "update-notifier": "2.3.0",
+            "uuid": "3.2.1",
+            "validate-npm-package-license": "3.0.1",
+            "validate-npm-package-name": "3.0.0",
+            "which": "1.3.0",
+            "worker-farm": "1.5.4",
+            "wrappy": "1.0.2",
+            "write-file-atomic": "2.3.0"
           },
           "dependencies": {
             "JSONStream": {
               "version": "1.3.2",
               "bundled": true,
               "requires": {
-                "jsonparse": "^1.2.0",
-                "through": ">=2.2.7 <3"
+                "jsonparse": "1.3.1",
+                "through": "2.3.8"
               },
               "dependencies": {
                 "jsonparse": {
@@ -8211,12 +8211,12 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.0",
-                "cmd-shim": "^2.0.2",
-                "fs-write-stream-atomic": "^1.0.10",
-                "gentle-fs": "^2.0.0",
-                "graceful-fs": "^4.1.11",
-                "slide": "^1.1.6"
+                "bluebird": "3.5.1",
+                "cmd-shim": "2.0.2",
+                "fs-write-stream-atomic": "1.0.10",
+                "gentle-fs": "2.0.1",
+                "graceful-fs": "4.1.11",
+                "slide": "1.1.6"
               }
             },
             "bluebird": {
@@ -8227,44 +8227,44 @@
               "version": "10.0.4",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
+                "bluebird": "3.5.1",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.1",
+                "mississippi": "2.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.2.4",
+                "unique-filename": "1.1.0",
+                "y18n": "4.0.0"
               },
               "dependencies": {
                 "mississippi": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^2.0.1",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
+                    "concat-stream": "1.6.1",
+                    "duplexify": "3.5.4",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.2",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "2.0.1",
+                    "pumpify": "1.4.0",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
                   },
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.6.1",
                       "bundled": true,
                       "requires": {
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
-                        "typedarray": "^0.0.6"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5",
+                        "typedarray": "0.0.6"
                       },
                       "dependencies": {
                         "typedarray": {
@@ -8277,10 +8277,10 @@
                       "version": "3.5.4",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "^1.0.0",
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0",
-                        "stream-shift": "^1.0.0"
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5",
+                        "stream-shift": "1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -8293,32 +8293,32 @@
                       "version": "1.4.1",
                       "bundled": true,
                       "requires": {
-                        "once": "^1.4.0"
+                        "once": "1.4.0"
                       }
                     },
                     "flush-write-stream": {
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.4"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5"
                       }
                     },
                     "from2": {
                       "version": "2.3.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5"
                       }
                     },
                     "parallel-transform": {
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "cyclist": "~0.2.2",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.1.5"
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -8331,25 +8331,25 @@
                       "version": "2.0.1",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
                       }
                     },
                     "pumpify": {
                       "version": "1.4.0",
                       "bundled": true,
                       "requires": {
-                        "duplexify": "^3.5.3",
-                        "inherits": "^2.0.3",
-                        "pump": "^2.0.0"
+                        "duplexify": "3.5.4",
+                        "inherits": "2.0.3",
+                        "pump": "2.0.1"
                       }
                     },
                     "stream-each": {
                       "version": "1.2.2",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "stream-shift": "^1.0.0"
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -8362,8 +8362,8 @@
                       "version": "2.0.3",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
+                        "readable-stream": "2.3.5",
+                        "xtend": "4.0.1"
                       },
                       "dependencies": {
                         "xtend": {
@@ -8392,9 +8392,9 @@
               "version": "0.2.0",
               "bundled": true,
               "requires": {
-                "colors": "^1.1.2",
-                "lodash": "^3.10.1",
-                "string-width": "^1.0.1"
+                "colors": "1.1.2",
+                "lodash": "3.10.1",
+                "string-width": "1.0.2"
               },
               "dependencies": {
                 "colors": {
@@ -8410,9 +8410,9 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
                   },
                   "dependencies": {
                     "code-point-at": {
@@ -8423,7 +8423,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -8436,7 +8436,7 @@
                       "version": "3.0.1",
                       "bundled": true,
                       "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -8453,23 +8453,23 @@
               "version": "2.0.2",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "~0.5.0"
+                "graceful-fs": "4.1.11",
+                "mkdirp": "0.5.1"
               }
             },
             "columnify": {
               "version": "1.5.4",
               "bundled": true,
               "requires": {
-                "strip-ansi": "^3.0.0",
-                "wcwidth": "^1.0.0"
+                "strip-ansi": "3.0.1",
+                "wcwidth": "1.0.1"
               },
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -8482,14 +8482,14 @@
                   "version": "1.0.1",
                   "bundled": true,
                   "requires": {
-                    "defaults": "^1.0.3"
+                    "defaults": "1.0.3"
                   },
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
                       "bundled": true,
                       "requires": {
-                        "clone": "^1.0.2"
+                        "clone": "1.0.2"
                       },
                       "dependencies": {
                         "clone": {
@@ -8506,8 +8506,8 @@
               "version": "1.1.11",
               "bundled": true,
               "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
+                "ini": "1.3.5",
+                "proto-list": "1.2.4"
               },
               "dependencies": {
                 "proto-list": {
@@ -8532,8 +8532,8 @@
               "version": "1.0.3",
               "bundled": true,
               "requires": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
+                "asap": "2.0.5",
+                "wrappy": "1.0.2"
               },
               "dependencies": {
                 "asap": {
@@ -8554,45 +8554,45 @@
               "version": "1.2.10",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "path-is-inside": "^1.0.1",
-                "rimraf": "^2.5.2"
+                "graceful-fs": "4.1.11",
+                "path-is-inside": "1.0.2",
+                "rimraf": "2.6.2"
               }
             },
             "fs-write-stream-atomic": {
               "version": "1.0.10",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
+                "graceful-fs": "4.1.11",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "2.3.5"
               }
             },
             "gentle-fs": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "aproba": "^1.1.2",
-                "fs-vacuum": "^1.2.10",
-                "graceful-fs": "^4.1.11",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "path-is-inside": "^1.0.2",
-                "read-cmd-shim": "^1.0.1",
-                "slide": "^1.1.6"
+                "aproba": "1.2.0",
+                "fs-vacuum": "1.2.10",
+                "graceful-fs": "4.1.11",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "path-is-inside": "1.0.2",
+                "read-cmd-shim": "1.0.1",
+                "slide": "1.1.6"
               }
             },
             "glob": {
               "version": "7.1.2",
               "bundled": true,
               "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               },
               "dependencies": {
                 "fs.realpath": {
@@ -8603,14 +8603,14 @@
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "^1.1.7"
+                    "brace-expansion": "1.1.8"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -8656,8 +8656,8 @@
               "version": "1.0.6",
               "bundled": true,
               "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
               }
             },
             "inherits": {
@@ -8672,21 +8672,21 @@
               "version": "1.10.3",
               "bundled": true,
               "requires": {
-                "glob": "^7.1.1",
-                "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-                "promzard": "^0.3.0",
-                "read": "~1.0.1",
-                "read-package-json": "1 || 2",
-                "semver": "2.x || 3.x || 4 || 5",
-                "validate-npm-package-license": "^3.0.1",
-                "validate-npm-package-name": "^3.0.0"
+                "glob": "7.1.2",
+                "npm-package-arg": "6.0.0",
+                "promzard": "0.3.0",
+                "read": "1.0.7",
+                "read-package-json": "2.0.13",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.1",
+                "validate-npm-package-name": "3.0.0"
               },
               "dependencies": {
                 "promzard": {
                   "version": "0.3.0",
                   "bundled": true,
                   "requires": {
-                    "read": "1"
+                    "read": "1.0.7"
                   }
                 }
               }
@@ -8716,37 +8716,37 @@
               "version": "1.6.0",
               "bundled": true,
               "requires": {
-                "bin-links": "^1.1.0",
-                "bluebird": "^3.5.1",
-                "find-npm-prefix": "^1.0.2",
-                "graceful-fs": "^4.1.11",
-                "lock-verify": "^2.0.0",
-                "npm-lifecycle": "^2.0.0",
-                "npm-logical-tree": "^1.2.1",
-                "npm-package-arg": "^6.0.0",
-                "pacote": "^7.5.1",
-                "protoduck": "^5.0.0",
-                "read-package-json": "^2.0.12",
-                "rimraf": "^2.6.2",
-                "worker-farm": "^1.5.4"
+                "bin-links": "1.1.0",
+                "bluebird": "3.5.1",
+                "find-npm-prefix": "1.0.2",
+                "graceful-fs": "4.1.11",
+                "lock-verify": "2.0.0",
+                "npm-lifecycle": "2.0.1",
+                "npm-logical-tree": "1.2.1",
+                "npm-package-arg": "6.0.0",
+                "pacote": "7.6.1",
+                "protoduck": "5.0.0",
+                "read-package-json": "2.0.13",
+                "rimraf": "2.6.2",
+                "worker-farm": "1.5.4"
               },
               "dependencies": {
                 "lock-verify": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "npm-package-arg": "^5.1.2",
-                    "semver": "^5.4.1"
+                    "npm-package-arg": "5.1.2",
+                    "semver": "5.5.0"
                   },
                   "dependencies": {
                     "npm-package-arg": {
                       "version": "5.1.2",
                       "bundled": true,
                       "requires": {
-                        "hosted-git-info": "^2.4.2",
-                        "osenv": "^0.1.4",
-                        "semver": "^5.1.0",
-                        "validate-npm-package-name": "^3.0.0"
+                        "hosted-git-info": "2.6.0",
+                        "osenv": "0.1.5",
+                        "semver": "5.5.0",
+                        "validate-npm-package-name": "3.0.0"
                       }
                     }
                   }
@@ -8759,7 +8759,7 @@
                   "version": "5.0.0",
                   "bundled": true,
                   "requires": {
-                    "genfun": "^4.0.1"
+                    "genfun": "4.0.1"
                   },
                   "dependencies": {
                     "genfun": {
@@ -8772,15 +8772,15 @@
                   "version": "1.5.4",
                   "bundled": true,
                   "requires": {
-                    "errno": "~0.1.7",
-                    "xtend": "~4.0.1"
+                    "errno": "0.1.7",
+                    "xtend": "4.0.1"
                   },
                   "dependencies": {
                     "errno": {
                       "version": "0.1.7",
                       "bundled": true,
                       "requires": {
-                        "prr": "~1.0.1"
+                        "prr": "1.0.1"
                       },
                       "dependencies": {
                         "prr": {
@@ -8801,14 +8801,14 @@
               "version": "10.0.1",
               "bundled": true,
               "requires": {
-                "dotenv": "^5.0.1",
-                "npm-package-arg": "^6.0.0",
-                "rimraf": "^2.6.2",
-                "safe-buffer": "^5.1.0",
-                "update-notifier": "^2.3.0",
-                "which": "^1.3.0",
-                "y18n": "^4.0.0",
-                "yargs": "^11.0.0"
+                "dotenv": "5.0.1",
+                "npm-package-arg": "6.0.0",
+                "rimraf": "2.6.2",
+                "safe-buffer": "5.1.1",
+                "update-notifier": "2.3.0",
+                "which": "1.3.0",
+                "y18n": "4.0.0",
+                "yargs": "11.0.0"
               },
               "dependencies": {
                 "dotenv": {
@@ -8823,44 +8823,44 @@
                   "version": "11.0.0",
                   "bundled": true,
                   "requires": {
-                    "cliui": "^4.0.0",
-                    "decamelize": "^1.1.1",
-                    "find-up": "^2.1.0",
-                    "get-caller-file": "^1.0.1",
-                    "os-locale": "^2.0.0",
-                    "require-directory": "^2.1.1",
-                    "require-main-filename": "^1.0.1",
-                    "set-blocking": "^2.0.0",
-                    "string-width": "^2.0.0",
-                    "which-module": "^2.0.0",
-                    "y18n": "^3.2.1",
-                    "yargs-parser": "^9.0.2"
+                    "cliui": "4.0.0",
+                    "decamelize": "1.2.0",
+                    "find-up": "2.1.0",
+                    "get-caller-file": "1.0.2",
+                    "os-locale": "2.1.0",
+                    "require-directory": "2.1.1",
+                    "require-main-filename": "1.0.1",
+                    "set-blocking": "2.0.0",
+                    "string-width": "2.1.1",
+                    "which-module": "2.0.0",
+                    "y18n": "3.2.1",
+                    "yargs-parser": "9.0.2"
                   },
                   "dependencies": {
                     "cliui": {
                       "version": "4.0.0",
                       "bundled": true,
                       "requires": {
-                        "string-width": "^2.1.1",
-                        "strip-ansi": "^4.0.0",
-                        "wrap-ansi": "^2.0.0"
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
+                        "wrap-ansi": "2.1.0"
                       },
                       "dependencies": {
                         "wrap-ansi": {
                           "version": "2.1.0",
                           "bundled": true,
                           "requires": {
-                            "string-width": "^1.0.1",
-                            "strip-ansi": "^3.0.1"
+                            "string-width": "1.0.2",
+                            "strip-ansi": "3.0.1"
                           },
                           "dependencies": {
                             "string-width": {
                               "version": "1.0.2",
                               "bundled": true,
                               "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
                               },
                               "dependencies": {
                                 "code-point-at": {
@@ -8871,7 +8871,7 @@
                                   "version": "1.0.0",
                                   "bundled": true,
                                   "requires": {
-                                    "number-is-nan": "^1.0.0"
+                                    "number-is-nan": "1.0.1"
                                   },
                                   "dependencies": {
                                     "number-is-nan": {
@@ -8886,7 +8886,7 @@
                               "version": "3.0.1",
                               "bundled": true,
                               "requires": {
-                                "ansi-regex": "^2.0.0"
+                                "ansi-regex": "2.1.1"
                               },
                               "dependencies": {
                                 "ansi-regex": {
@@ -8907,29 +8907,29 @@
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                       },
                       "dependencies": {
                         "locate-path": {
                           "version": "2.0.0",
                           "bundled": true,
                           "requires": {
-                            "p-locate": "^2.0.0",
-                            "path-exists": "^3.0.0"
+                            "p-locate": "2.0.0",
+                            "path-exists": "3.0.0"
                           },
                           "dependencies": {
                             "p-locate": {
                               "version": "2.0.0",
                               "bundled": true,
                               "requires": {
-                                "p-limit": "^1.1.0"
+                                "p-limit": "1.2.0"
                               },
                               "dependencies": {
                                 "p-limit": {
                                   "version": "1.2.0",
                                   "bundled": true,
                                   "requires": {
-                                    "p-try": "^1.0.0"
+                                    "p-try": "1.0.0"
                                   },
                                   "dependencies": {
                                     "p-try": {
@@ -8956,38 +8956,38 @@
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
                       },
                       "dependencies": {
                         "execa": {
                           "version": "0.7.0",
                           "bundled": true,
                           "requires": {
-                            "cross-spawn": "^5.0.1",
-                            "get-stream": "^3.0.0",
-                            "is-stream": "^1.1.0",
-                            "npm-run-path": "^2.0.0",
-                            "p-finally": "^1.0.0",
-                            "signal-exit": "^3.0.0",
-                            "strip-eof": "^1.0.0"
+                            "cross-spawn": "5.1.0",
+                            "get-stream": "3.0.0",
+                            "is-stream": "1.1.0",
+                            "npm-run-path": "2.0.2",
+                            "p-finally": "1.0.0",
+                            "signal-exit": "3.0.2",
+                            "strip-eof": "1.0.0"
                           },
                           "dependencies": {
                             "cross-spawn": {
                               "version": "5.1.0",
                               "bundled": true,
                               "requires": {
-                                "lru-cache": "^4.0.1",
-                                "shebang-command": "^1.2.0",
-                                "which": "^1.2.9"
+                                "lru-cache": "4.1.1",
+                                "shebang-command": "1.2.0",
+                                "which": "1.3.0"
                               },
                               "dependencies": {
                                 "shebang-command": {
                                   "version": "1.2.0",
                                   "bundled": true,
                                   "requires": {
-                                    "shebang-regex": "^1.0.0"
+                                    "shebang-regex": "1.0.0"
                                   },
                                   "dependencies": {
                                     "shebang-regex": {
@@ -9010,7 +9010,7 @@
                               "version": "2.0.2",
                               "bundled": true,
                               "requires": {
-                                "path-key": "^2.0.0"
+                                "path-key": "2.0.1"
                               },
                               "dependencies": {
                                 "path-key": {
@@ -9037,7 +9037,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "requires": {
-                            "invert-kv": "^1.0.0"
+                            "invert-kv": "1.0.0"
                           },
                           "dependencies": {
                             "invert-kv": {
@@ -9050,7 +9050,7 @@
                           "version": "1.1.0",
                           "bundled": true,
                           "requires": {
-                            "mimic-fn": "^1.0.0"
+                            "mimic-fn": "1.2.0"
                           },
                           "dependencies": {
                             "mimic-fn": {
@@ -9077,8 +9077,8 @@
                       "version": "2.1.1",
                       "bundled": true,
                       "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                       },
                       "dependencies": {
                         "is-fullwidth-code-point": {
@@ -9099,7 +9099,7 @@
                       "version": "9.0.2",
                       "bundled": true,
                       "requires": {
-                        "camelcase": "^4.1.0"
+                        "camelcase": "4.1.0"
                       },
                       "dependencies": {
                         "camelcase": {
@@ -9124,8 +9124,8 @@
               "version": "4.6.0",
               "bundled": true,
               "requires": {
-                "lodash._createset": "~4.0.0",
-                "lodash._root": "~3.0.0"
+                "lodash._createset": "4.0.3",
+                "lodash._root": "3.0.1"
               },
               "dependencies": {
                 "lodash._createset": {
@@ -9150,7 +9150,7 @@
               "version": "3.1.2",
               "bundled": true,
               "requires": {
-                "lodash._getnative": "^3.0.0"
+                "lodash._getnative": "3.9.1"
               }
             },
             "lodash._getnative": {
@@ -9181,8 +9181,8 @@
               "version": "4.1.1",
               "bundled": true,
               "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
               },
               "dependencies": {
                 "pseudomap": {
@@ -9203,25 +9203,25 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^3.0.0",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
+                "concat-stream": "1.6.1",
+                "duplexify": "3.5.4",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.0.2",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "3.0.0",
+                "pumpify": "1.4.0",
+                "stream-each": "1.2.2",
+                "through2": "2.0.3"
               },
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.1",
                   "bundled": true,
                   "requires": {
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.2.2",
-                    "typedarray": "^0.0.6"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5",
+                    "typedarray": "0.0.6"
                   },
                   "dependencies": {
                     "typedarray": {
@@ -9234,10 +9234,10 @@
                   "version": "3.5.4",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "^1.0.0",
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0",
-                    "stream-shift": "^1.0.0"
+                    "end-of-stream": "1.4.1",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5",
+                    "stream-shift": "1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -9250,32 +9250,32 @@
                   "version": "1.4.1",
                   "bundled": true,
                   "requires": {
-                    "once": "^1.4.0"
+                    "once": "1.4.0"
                   }
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.4"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5"
                   }
                 },
                 "from2": {
                   "version": "2.3.0",
                   "bundled": true,
                   "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5"
                   }
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
                   "bundled": true,
                   "requires": {
-                    "cyclist": "~0.2.2",
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.1.5"
+                    "cyclist": "0.2.2",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5"
                   },
                   "dependencies": {
                     "cyclist": {
@@ -9288,25 +9288,25 @@
                   "version": "3.0.0",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
                   }
                 },
                 "pumpify": {
                   "version": "1.4.0",
                   "bundled": true,
                   "requires": {
-                    "duplexify": "^3.5.3",
-                    "inherits": "^2.0.3",
-                    "pump": "^2.0.0"
+                    "duplexify": "3.5.4",
+                    "inherits": "2.0.3",
+                    "pump": "2.0.1"
                   },
                   "dependencies": {
                     "pump": {
                       "version": "2.0.1",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
                       }
                     }
                   }
@@ -9315,8 +9315,8 @@
                   "version": "1.2.2",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "stream-shift": "^1.0.0"
+                    "end-of-stream": "1.4.1",
+                    "stream-shift": "1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -9329,8 +9329,8 @@
                   "version": "2.0.3",
                   "bundled": true,
                   "requires": {
-                    "readable-stream": "^2.1.5",
-                    "xtend": "~4.0.1"
+                    "readable-stream": "2.3.5",
+                    "xtend": "4.0.1"
                   },
                   "dependencies": {
                     "xtend": {
@@ -9358,31 +9358,31 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
+                "aproba": "1.2.0",
+                "copy-concurrently": "1.0.5",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
               },
               "dependencies": {
                 "copy-concurrently": {
                   "version": "1.0.5",
                   "bundled": true,
                   "requires": {
-                    "aproba": "^1.1.1",
-                    "fs-write-stream-atomic": "^1.0.8",
-                    "iferr": "^0.1.5",
-                    "mkdirp": "^0.5.1",
-                    "rimraf": "^2.5.4",
-                    "run-queue": "^1.0.0"
+                    "aproba": "1.2.0",
+                    "fs-write-stream-atomic": "1.0.10",
+                    "iferr": "0.1.5",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.2",
+                    "run-queue": "1.0.3"
                   }
                 },
                 "run-queue": {
                   "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "aproba": "^1.1.1"
+                    "aproba": "1.2.0"
                   }
                 }
               }
@@ -9391,25 +9391,25 @@
               "version": "4.0.1",
               "bundled": true,
               "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1.1.1",
+                "osenv": "0.1.5"
               }
             },
             "normalize-package-data": {
               "version": "2.4.0",
               "bundled": true,
               "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.6.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.1"
               },
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "builtin-modules": "^1.0.0"
+                    "builtin-modules": "1.1.1"
                   },
                   "dependencies": {
                     "builtin-modules": {
@@ -9428,21 +9428,21 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "semver": "^2.3.0 || 3.x || 4 || 5"
+                "semver": "5.5.0"
               }
             },
             "npm-lifecycle": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "byline": "^5.0.0",
-                "graceful-fs": "^4.1.11",
-                "node-gyp": "^3.6.2",
-                "resolve-from": "^4.0.0",
-                "slide": "^1.1.6",
+                "byline": "5.0.0",
+                "graceful-fs": "4.1.11",
+                "node-gyp": "3.6.2",
+                "resolve-from": "4.0.0",
+                "slide": "1.1.6",
                 "uid-number": "0.0.6",
-                "umask": "^1.1.0",
-                "which": "^1.3.0"
+                "umask": "1.1.0",
+                "which": "1.3.0"
               },
               "dependencies": {
                 "byline": {
@@ -9453,43 +9453,43 @@
                   "version": "3.6.2",
                   "bundled": true,
                   "requires": {
-                    "fstream": "^1.0.0",
-                    "glob": "^7.0.3",
-                    "graceful-fs": "^4.1.2",
-                    "minimatch": "^3.0.2",
-                    "mkdirp": "^0.5.0",
-                    "nopt": "2 || 3",
-                    "npmlog": "0 || 1 || 2 || 3 || 4",
-                    "osenv": "0",
-                    "request": "2",
-                    "rimraf": "2",
-                    "semver": "~5.3.0",
-                    "tar": "^2.0.0",
-                    "which": "1"
+                    "fstream": "1.0.11",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "minimatch": "3.0.4",
+                    "mkdirp": "0.5.1",
+                    "nopt": "3.0.6",
+                    "npmlog": "4.1.2",
+                    "osenv": "0.1.5",
+                    "request": "2.83.0",
+                    "rimraf": "2.6.2",
+                    "semver": "5.3.0",
+                    "tar": "2.2.1",
+                    "which": "1.3.0"
                   },
                   "dependencies": {
                     "fstream": {
                       "version": "1.0.11",
                       "bundled": true,
                       "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "inherits": "~2.0.0",
-                        "mkdirp": ">=0.5 0",
-                        "rimraf": "2"
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2"
                       }
                     },
                     "minimatch": {
                       "version": "3.0.4",
                       "bundled": true,
                       "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                       },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.11",
                           "bundled": true,
                           "requires": {
-                            "balanced-match": "^1.0.0",
+                            "balanced-match": "1.0.0",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -9509,7 +9509,7 @@
                       "version": "3.0.6",
                       "bundled": true,
                       "requires": {
-                        "abbrev": "1"
+                        "abbrev": "1.1.1"
                       }
                     },
                     "semver": {
@@ -9520,16 +9520,16 @@
                       "version": "2.2.1",
                       "bundled": true,
                       "requires": {
-                        "block-stream": "*",
-                        "fstream": "^1.0.2",
-                        "inherits": "2"
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
                       },
                       "dependencies": {
                         "block-stream": {
                           "version": "0.0.9",
                           "bundled": true,
                           "requires": {
-                            "inherits": "~2.0.0"
+                            "inherits": "2.0.3"
                           }
                         }
                       }
@@ -9546,39 +9546,39 @@
               "version": "6.0.0",
               "bundled": true,
               "requires": {
-                "hosted-git-info": "^2.5.0",
-                "osenv": "^0.1.4",
-                "semver": "^5.4.1",
-                "validate-npm-package-name": "^3.0.0"
+                "hosted-git-info": "2.6.0",
+                "osenv": "0.1.5",
+                "semver": "5.5.0",
+                "validate-npm-package-name": "3.0.0"
               }
             },
             "npm-packlist": {
               "version": "1.1.10",
               "bundled": true,
               "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
+                "ignore-walk": "3.0.1",
+                "npm-bundled": "1.0.3"
               },
               "dependencies": {
                 "ignore-walk": {
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "minimatch": "^3.0.4"
+                    "minimatch": "3.0.4"
                   },
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.4",
                       "bundled": true,
                       "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.8"
                       },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.8",
                           "bundled": true,
                           "requires": {
-                            "balanced-match": "^1.0.0",
+                            "balanced-match": "1.0.0",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -9606,39 +9606,39 @@
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "aproba": "^1.1.2",
-                "make-fetch-happen": "^2.5.0"
+                "aproba": "1.2.0",
+                "make-fetch-happen": "2.6.0"
               },
               "dependencies": {
                 "make-fetch-happen": {
                   "version": "2.6.0",
                   "bundled": true,
                   "requires": {
-                    "agentkeepalive": "^3.3.0",
-                    "cacache": "^10.0.0",
-                    "http-cache-semantics": "^3.8.0",
-                    "http-proxy-agent": "^2.0.0",
-                    "https-proxy-agent": "^2.1.0",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^1.2.0",
-                    "node-fetch-npm": "^2.0.2",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^3.0.1",
-                    "ssri": "^5.0.0"
+                    "agentkeepalive": "3.3.0",
+                    "cacache": "10.0.4",
+                    "http-cache-semantics": "3.8.1",
+                    "http-proxy-agent": "2.0.0",
+                    "https-proxy-agent": "2.1.1",
+                    "lru-cache": "4.1.1",
+                    "mississippi": "1.3.1",
+                    "node-fetch-npm": "2.0.2",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "3.0.1",
+                    "ssri": "5.2.4"
                   },
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.3.0",
                       "bundled": true,
                       "requires": {
-                        "humanize-ms": "^1.2.1"
+                        "humanize-ms": "1.2.1"
                       },
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
                           "bundled": true,
                           "requires": {
-                            "ms": "^2.0.0"
+                            "ms": "2.1.1"
                           },
                           "dependencies": {
                             "ms": {
@@ -9657,22 +9657,22 @@
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "4",
-                        "debug": "2"
+                        "agent-base": "4.2.0",
+                        "debug": "2.6.9"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -9702,22 +9702,22 @@
                       "version": "2.1.1",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^3.1.0"
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -9747,25 +9747,25 @@
                       "version": "1.3.1",
                       "bundled": true,
                       "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^1.0.0",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
+                        "concat-stream": "1.6.0",
+                        "duplexify": "3.5.3",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.2",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "1.0.3",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
                       },
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.6.0",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.5",
+                            "typedarray": "0.0.6"
                           },
                           "dependencies": {
                             "typedarray": {
@@ -9778,10 +9778,10 @@
                           "version": "3.5.3",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.5",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -9794,32 +9794,32 @@
                           "version": "1.4.1",
                           "bundled": true,
                           "requires": {
-                            "once": "^1.4.0"
+                            "once": "1.4.0"
                           }
                         },
                         "flush-write-stream": {
                           "version": "1.0.2",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.5"
                           }
                         },
                         "from2": {
                           "version": "2.3.0",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.5"
                           }
                         },
                         "parallel-transform": {
                           "version": "1.1.0",
                           "bundled": true,
                           "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.5"
                           },
                           "dependencies": {
                             "cyclist": {
@@ -9832,25 +9832,25 @@
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
                           }
                         },
                         "pumpify": {
                           "version": "1.4.0",
                           "bundled": true,
                           "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
+                            "duplexify": "3.5.3",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
                           },
                           "dependencies": {
                             "pump": {
                               "version": "2.0.1",
                               "bundled": true,
                               "requires": {
-                                "end-of-stream": "^1.1.0",
-                                "once": "^1.3.1"
+                                "end-of-stream": "1.4.1",
+                                "once": "1.4.0"
                               }
                             }
                           }
@@ -9859,8 +9859,8 @@
                           "version": "1.2.2",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -9873,8 +9873,8 @@
                           "version": "2.0.3",
                           "bundled": true,
                           "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
+                            "readable-stream": "2.3.5",
+                            "xtend": "4.0.1"
                           },
                           "dependencies": {
                             "xtend": {
@@ -9889,16 +9889,16 @@
                       "version": "2.0.2",
                       "bundled": true,
                       "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-better-errors": "^1.0.0",
-                        "safe-buffer": "^5.1.1"
+                        "encoding": "0.1.12",
+                        "json-parse-better-errors": "1.0.1",
+                        "safe-buffer": "5.1.1"
                       },
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
                           "bundled": true,
                           "requires": {
-                            "iconv-lite": "~0.4.13"
+                            "iconv-lite": "0.4.19"
                           },
                           "dependencies": {
                             "iconv-lite": {
@@ -9917,8 +9917,8 @@
                       "version": "1.1.1",
                       "bundled": true,
                       "requires": {
-                        "err-code": "^1.0.0",
-                        "retry": "^0.10.0"
+                        "err-code": "1.1.2",
+                        "retry": "0.10.1"
                       },
                       "dependencies": {
                         "err-code": {
@@ -9931,22 +9931,22 @@
                       "version": "3.0.1",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "^4.1.0",
-                        "socks": "^1.1.10"
+                        "agent-base": "4.2.0",
+                        "socks": "1.1.10"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -9961,8 +9961,8 @@
                           "version": "1.1.10",
                           "bundled": true,
                           "requires": {
-                            "ip": "^1.1.4",
-                            "smart-buffer": "^1.0.13"
+                            "ip": "1.1.5",
+                            "smart-buffer": "1.1.15"
                           },
                           "dependencies": {
                             "ip": {
@@ -9985,27 +9985,27 @@
               "version": "8.5.1",
               "bundled": true,
               "requires": {
-                "concat-stream": "^1.5.2",
-                "graceful-fs": "^4.1.6",
-                "normalize-package-data": "~1.0.1 || ^2.0.0",
-                "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-                "npmlog": "2 || ^3.1.0 || ^4.0.0",
-                "once": "^1.3.3",
-                "request": "^2.74.0",
-                "retry": "^0.10.0",
-                "safe-buffer": "^5.1.1",
-                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-                "slide": "^1.1.3",
-                "ssri": "^5.2.4"
+                "concat-stream": "1.6.1",
+                "graceful-fs": "4.1.11",
+                "normalize-package-data": "2.4.0",
+                "npm-package-arg": "6.0.0",
+                "npmlog": "4.1.2",
+                "once": "1.4.0",
+                "request": "2.83.0",
+                "retry": "0.10.1",
+                "safe-buffer": "5.1.1",
+                "semver": "5.5.0",
+                "slide": "1.1.6",
+                "ssri": "5.2.4"
               },
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.1",
                   "bundled": true,
                   "requires": {
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.2.2",
-                    "typedarray": "^0.0.6"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.5",
+                    "typedarray": "0.0.6"
                   },
                   "dependencies": {
                     "typedarray": {
@@ -10024,18 +10024,18 @@
               "version": "4.1.2",
               "bundled": true,
               "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
               },
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.4",
                   "bundled": true,
                   "requires": {
-                    "delegates": "^1.0.0",
-                    "readable-stream": "^2.0.6"
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.3.5"
                   },
                   "dependencies": {
                     "delegates": {
@@ -10052,14 +10052,14 @@
                   "version": "2.7.4",
                   "bundled": true,
                   "requires": {
-                    "aproba": "^1.0.3",
-                    "console-control-strings": "^1.0.0",
-                    "has-unicode": "^2.0.0",
-                    "object-assign": "^4.1.0",
-                    "signal-exit": "^3.0.0",
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1",
-                    "wide-align": "^1.1.0"
+                    "aproba": "1.2.0",
+                    "console-control-strings": "1.1.0",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.1",
+                    "signal-exit": "3.0.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.2"
                   },
                   "dependencies": {
                     "object-assign": {
@@ -10074,9 +10074,9 @@
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                       },
                       "dependencies": {
                         "code-point-at": {
@@ -10087,7 +10087,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "requires": {
-                            "number-is-nan": "^1.0.0"
+                            "number-is-nan": "1.0.1"
                           },
                           "dependencies": {
                             "number-is-nan": {
@@ -10102,7 +10102,7 @@
                       "version": "3.0.1",
                       "bundled": true,
                       "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -10115,7 +10115,7 @@
                       "version": "1.1.2",
                       "bundled": true,
                       "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "1.0.2"
                       }
                     }
                   }
@@ -10130,7 +10130,7 @@
               "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
               }
             },
             "opener": {
@@ -10141,8 +10141,8 @@
               "version": "0.1.5",
               "bundled": true,
               "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
               },
               "dependencies": {
                 "os-homedir": {
@@ -10159,30 +10159,30 @@
               "version": "7.6.1",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "cacache": "^10.0.4",
-                "get-stream": "^3.0.0",
-                "glob": "^7.1.2",
-                "lru-cache": "^4.1.1",
-                "make-fetch-happen": "^2.6.0",
-                "minimatch": "^3.0.4",
-                "mississippi": "^3.0.0",
-                "mkdirp": "^0.5.1",
-                "normalize-package-data": "^2.4.0",
-                "npm-package-arg": "^6.0.0",
-                "npm-packlist": "^1.1.10",
-                "npm-pick-manifest": "^2.1.0",
-                "osenv": "^0.1.5",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^1.1.1",
-                "protoduck": "^5.0.0",
-                "rimraf": "^2.6.2",
-                "safe-buffer": "^5.1.1",
-                "semver": "^5.5.0",
-                "ssri": "^5.2.4",
-                "tar": "^4.4.0",
-                "unique-filename": "^1.1.0",
-                "which": "^1.3.0"
+                "bluebird": "3.5.1",
+                "cacache": "10.0.4",
+                "get-stream": "3.0.0",
+                "glob": "7.1.2",
+                "lru-cache": "4.1.1",
+                "make-fetch-happen": "2.6.0",
+                "minimatch": "3.0.4",
+                "mississippi": "3.0.0",
+                "mkdirp": "0.5.1",
+                "normalize-package-data": "2.4.0",
+                "npm-package-arg": "6.0.0",
+                "npm-packlist": "1.1.10",
+                "npm-pick-manifest": "2.1.0",
+                "osenv": "0.1.5",
+                "promise-inflight": "1.0.1",
+                "promise-retry": "1.1.1",
+                "protoduck": "5.0.0",
+                "rimraf": "2.6.2",
+                "safe-buffer": "5.1.1",
+                "semver": "5.5.0",
+                "ssri": "5.2.4",
+                "tar": "4.4.0",
+                "unique-filename": "1.1.0",
+                "which": "1.3.0"
               },
               "dependencies": {
                 "get-stream": {
@@ -10193,31 +10193,31 @@
                   "version": "2.6.0",
                   "bundled": true,
                   "requires": {
-                    "agentkeepalive": "^3.3.0",
-                    "cacache": "^10.0.0",
-                    "http-cache-semantics": "^3.8.0",
-                    "http-proxy-agent": "^2.0.0",
-                    "https-proxy-agent": "^2.1.0",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^1.2.0",
-                    "node-fetch-npm": "^2.0.2",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^3.0.1",
-                    "ssri": "^5.0.0"
+                    "agentkeepalive": "3.4.0",
+                    "cacache": "10.0.4",
+                    "http-cache-semantics": "3.8.1",
+                    "http-proxy-agent": "2.1.0",
+                    "https-proxy-agent": "2.2.0",
+                    "lru-cache": "4.1.1",
+                    "mississippi": "1.3.1",
+                    "node-fetch-npm": "2.0.2",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "3.0.1",
+                    "ssri": "5.2.4"
                   },
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.4.0",
                       "bundled": true,
                       "requires": {
-                        "humanize-ms": "^1.2.1"
+                        "humanize-ms": "1.2.1"
                       },
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
                           "bundled": true,
                           "requires": {
-                            "ms": "^2.0.0"
+                            "ms": "2.1.1"
                           },
                           "dependencies": {
                             "ms": {
@@ -10236,7 +10236,7 @@
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "4",
+                        "agent-base": "4.2.0",
                         "debug": "3.1.0"
                       },
                       "dependencies": {
@@ -10244,14 +10244,14 @@
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -10281,22 +10281,22 @@
                       "version": "2.2.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^3.1.0"
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -10326,25 +10326,25 @@
                       "version": "1.3.1",
                       "bundled": true,
                       "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^1.0.0",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
+                        "concat-stream": "1.6.1",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.2",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "1.0.3",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
                       },
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.6.1",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.5",
+                            "typedarray": "0.0.6"
                           },
                           "dependencies": {
                             "typedarray": {
@@ -10357,10 +10357,10 @@
                           "version": "3.5.4",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.5",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -10373,32 +10373,32 @@
                           "version": "1.4.1",
                           "bundled": true,
                           "requires": {
-                            "once": "^1.4.0"
+                            "once": "1.4.0"
                           }
                         },
                         "flush-write-stream": {
                           "version": "1.0.2",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.5"
                           }
                         },
                         "from2": {
                           "version": "2.3.0",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.5"
                           }
                         },
                         "parallel-transform": {
                           "version": "1.1.0",
                           "bundled": true,
                           "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.5"
                           },
                           "dependencies": {
                             "cyclist": {
@@ -10411,25 +10411,25 @@
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
                           }
                         },
                         "pumpify": {
                           "version": "1.4.0",
                           "bundled": true,
                           "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
                           },
                           "dependencies": {
                             "pump": {
                               "version": "2.0.1",
                               "bundled": true,
                               "requires": {
-                                "end-of-stream": "^1.1.0",
-                                "once": "^1.3.1"
+                                "end-of-stream": "1.4.1",
+                                "once": "1.4.0"
                               }
                             }
                           }
@@ -10438,8 +10438,8 @@
                           "version": "1.2.2",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -10452,8 +10452,8 @@
                           "version": "2.0.3",
                           "bundled": true,
                           "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
+                            "readable-stream": "2.3.5",
+                            "xtend": "4.0.1"
                           },
                           "dependencies": {
                             "xtend": {
@@ -10468,16 +10468,16 @@
                       "version": "2.0.2",
                       "bundled": true,
                       "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-better-errors": "^1.0.0",
-                        "safe-buffer": "^5.1.1"
+                        "encoding": "0.1.12",
+                        "json-parse-better-errors": "1.0.1",
+                        "safe-buffer": "5.1.1"
                       },
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
                           "bundled": true,
                           "requires": {
-                            "iconv-lite": "~0.4.13"
+                            "iconv-lite": "0.4.19"
                           },
                           "dependencies": {
                             "iconv-lite": {
@@ -10496,22 +10496,22 @@
                       "version": "3.0.1",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "^4.1.0",
-                        "socks": "^1.1.10"
+                        "agent-base": "4.2.0",
+                        "socks": "1.1.10"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -10526,8 +10526,8 @@
                           "version": "1.1.10",
                           "bundled": true,
                           "requires": {
-                            "ip": "^1.1.4",
-                            "smart-buffer": "^1.0.13"
+                            "ip": "1.1.5",
+                            "smart-buffer": "1.1.15"
                           },
                           "dependencies": {
                             "ip": {
@@ -10548,14 +10548,14 @@
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "^1.1.7"
+                    "brace-expansion": "1.1.11"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.11",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -10575,16 +10575,16 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "npm-package-arg": "^6.0.0",
-                    "semver": "^5.4.1"
+                    "npm-package-arg": "6.0.0",
+                    "semver": "5.5.0"
                   }
                 },
                 "promise-retry": {
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
                   },
                   "dependencies": {
                     "err-code": {
@@ -10597,7 +10597,7 @@
                   "version": "5.0.0",
                   "bundled": true,
                   "requires": {
-                    "genfun": "^4.0.1"
+                    "genfun": "4.0.1"
                   },
                   "dependencies": {
                     "genfun": {
@@ -10624,9 +10624,9 @@
               "version": "5.1.0",
               "bundled": true,
               "requires": {
-                "decode-uri-component": "^0.2.0",
-                "object-assign": "^4.1.0",
-                "strict-uri-encode": "^1.0.0"
+                "decode-uri-component": "0.2.0",
+                "object-assign": "4.1.1",
+                "strict-uri-encode": "1.1.0"
               },
               "dependencies": {
                 "decode-uri-component": {
@@ -10651,7 +10651,7 @@
               "version": "1.0.7",
               "bundled": true,
               "requires": {
-                "mute-stream": "~0.0.4"
+                "mute-stream": "0.0.7"
               },
               "dependencies": {
                 "mute-stream": {
@@ -10664,20 +10664,20 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2"
+                "graceful-fs": "4.1.11"
               }
             },
             "read-installed": {
               "version": "4.0.3",
               "bundled": true,
               "requires": {
-                "debuglog": "^1.0.1",
-                "graceful-fs": "^4.1.2",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "slide": "~1.1.3",
-                "util-extend": "^1.0.1"
+                "debuglog": "1.0.1",
+                "graceful-fs": "4.1.11",
+                "read-package-json": "2.0.13",
+                "readdir-scoped-modules": "1.0.2",
+                "semver": "5.5.0",
+                "slide": "1.1.6",
+                "util-extend": "1.0.3"
               },
               "dependencies": {
                 "util-extend": {
@@ -10690,11 +10690,11 @@
               "version": "2.0.13",
               "bundled": true,
               "requires": {
-                "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "json-parse-better-errors": "^1.0.1",
-                "normalize-package-data": "^2.0.0",
-                "slash": "^1.0.0"
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "json-parse-better-errors": "1.0.1",
+                "normalize-package-data": "2.4.0",
+                "slash": "1.0.0"
               },
               "dependencies": {
                 "json-parse-better-errors": {
@@ -10711,24 +10711,24 @@
               "version": "5.1.6",
               "bundled": true,
               "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "once": "^1.3.0",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0"
+                "debuglog": "1.0.1",
+                "dezalgo": "1.0.3",
+                "once": "1.4.0",
+                "read-package-json": "2.0.13",
+                "readdir-scoped-modules": "1.0.2"
               }
             },
             "readable-stream": {
               "version": "2.3.5",
               "bundled": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.0.3",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
               },
               "dependencies": {
                 "core-util-is": {
@@ -10747,7 +10747,7 @@
                   "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "safe-buffer": "~5.1.0"
+                    "safe-buffer": "5.1.1"
                   }
                 },
                 "util-deprecate": {
@@ -10760,38 +10760,38 @@
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "graceful-fs": "^4.1.2",
-                "once": "^1.3.0"
+                "debuglog": "1.0.1",
+                "dezalgo": "1.0.3",
+                "graceful-fs": "4.1.11",
+                "once": "1.4.0"
               }
             },
             "request": {
               "version": "2.83.0",
               "bundled": true,
               "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "hawk": "~6.0.2",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "stringstream": "~0.0.5",
-                "tough-cookie": "~2.3.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
               },
               "dependencies": {
                 "aws-sign2": {
@@ -10810,7 +10810,7 @@
                   "version": "1.0.5",
                   "bundled": true,
                   "requires": {
-                    "delayed-stream": "~1.0.0"
+                    "delayed-stream": "1.0.0"
                   },
                   "dependencies": {
                     "delayed-stream": {
@@ -10831,9 +10831,9 @@
                   "version": "2.3.1",
                   "bundled": true,
                   "requires": {
-                    "asynckit": "^0.4.0",
-                    "combined-stream": "^1.0.5",
-                    "mime-types": "^2.1.12"
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.17"
                   },
                   "dependencies": {
                     "asynckit": {
@@ -10846,18 +10846,18 @@
                   "version": "5.0.3",
                   "bundled": true,
                   "requires": {
-                    "ajv": "^5.1.0",
-                    "har-schema": "^2.0.0"
+                    "ajv": "5.2.3",
+                    "har-schema": "2.0.0"
                   },
                   "dependencies": {
                     "ajv": {
                       "version": "5.2.3",
                       "bundled": true,
                       "requires": {
-                        "co": "^4.6.0",
-                        "fast-deep-equal": "^1.0.0",
-                        "json-schema-traverse": "^0.3.0",
-                        "json-stable-stringify": "^1.0.1"
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.0.0",
+                        "json-schema-traverse": "0.3.1",
+                        "json-stable-stringify": "1.0.1"
                       },
                       "dependencies": {
                         "co": {
@@ -10876,7 +10876,7 @@
                           "version": "1.0.1",
                           "bundled": true,
                           "requires": {
-                            "jsonify": "~0.0.0"
+                            "jsonify": "0.0.0"
                           },
                           "dependencies": {
                             "jsonify": {
@@ -10897,31 +10897,31 @@
                   "version": "6.0.2",
                   "bundled": true,
                   "requires": {
-                    "boom": "4.x.x",
-                    "cryptiles": "3.x.x",
-                    "hoek": "4.x.x",
-                    "sntp": "2.x.x"
+                    "boom": "4.3.1",
+                    "cryptiles": "3.1.2",
+                    "hoek": "4.2.0",
+                    "sntp": "2.0.2"
                   },
                   "dependencies": {
                     "boom": {
                       "version": "4.3.1",
                       "bundled": true,
                       "requires": {
-                        "hoek": "4.x.x"
+                        "hoek": "4.2.0"
                       }
                     },
                     "cryptiles": {
                       "version": "3.1.2",
                       "bundled": true,
                       "requires": {
-                        "boom": "5.x.x"
+                        "boom": "5.2.0"
                       },
                       "dependencies": {
                         "boom": {
                           "version": "5.2.0",
                           "bundled": true,
                           "requires": {
-                            "hoek": "4.x.x"
+                            "hoek": "4.2.0"
                           }
                         }
                       }
@@ -10934,7 +10934,7 @@
                       "version": "2.0.2",
                       "bundled": true,
                       "requires": {
-                        "hoek": "4.x.x"
+                        "hoek": "4.2.0"
                       }
                     }
                   }
@@ -10943,9 +10943,9 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "assert-plus": "^1.0.0",
-                    "jsprim": "^1.2.2",
-                    "sshpk": "^1.7.0"
+                    "assert-plus": "1.0.0",
+                    "jsprim": "1.4.1",
+                    "sshpk": "1.13.1"
                   },
                   "dependencies": {
                     "assert-plus": {
@@ -10974,9 +10974,9 @@
                           "version": "1.10.0",
                           "bundled": true,
                           "requires": {
-                            "assert-plus": "^1.0.0",
+                            "assert-plus": "1.0.0",
                             "core-util-is": "1.0.2",
-                            "extsprintf": "^1.2.0"
+                            "extsprintf": "1.3.0"
                           },
                           "dependencies": {
                             "core-util-is": {
@@ -10991,14 +10991,14 @@
                       "version": "1.13.1",
                       "bundled": true,
                       "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "bcrypt-pbkdf": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jsbn": "~0.1.0",
-                        "tweetnacl": "~0.14.0"
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
                       },
                       "dependencies": {
                         "asn1": {
@@ -11010,14 +11010,14 @@
                           "bundled": true,
                           "optional": true,
                           "requires": {
-                            "tweetnacl": "^0.14.3"
+                            "tweetnacl": "0.14.5"
                           }
                         },
                         "dashdash": {
                           "version": "1.14.1",
                           "bundled": true,
                           "requires": {
-                            "assert-plus": "^1.0.0"
+                            "assert-plus": "1.0.0"
                           }
                         },
                         "ecc-jsbn": {
@@ -11025,14 +11025,14 @@
                           "bundled": true,
                           "optional": true,
                           "requires": {
-                            "jsbn": "~0.1.0"
+                            "jsbn": "0.1.1"
                           }
                         },
                         "getpass": {
                           "version": "0.1.7",
                           "bundled": true,
                           "requires": {
-                            "assert-plus": "^1.0.0"
+                            "assert-plus": "1.0.0"
                           }
                         },
                         "jsbn": {
@@ -11065,7 +11065,7 @@
                   "version": "2.1.17",
                   "bundled": true,
                   "requires": {
-                    "mime-db": "~1.30.0"
+                    "mime-db": "1.30.0"
                   },
                   "dependencies": {
                     "mime-db": {
@@ -11094,7 +11094,7 @@
                   "version": "2.3.3",
                   "bundled": true,
                   "requires": {
-                    "punycode": "^1.4.1"
+                    "punycode": "1.4.1"
                   },
                   "dependencies": {
                     "punycode": {
@@ -11107,7 +11107,7 @@
                   "version": "0.6.0",
                   "bundled": true,
                   "requires": {
-                    "safe-buffer": "^5.0.1"
+                    "safe-buffer": "5.1.1"
                   }
                 }
               }
@@ -11120,7 +11120,7 @@
               "version": "2.6.2",
               "bundled": true,
               "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
               }
             },
             "safe-buffer": {
@@ -11135,8 +11135,8 @@
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "readable-stream": "^2.0.2"
+                "graceful-fs": "4.1.11",
+                "readable-stream": "2.3.5"
               }
             },
             "slide": {
@@ -11151,26 +11151,26 @@
               "version": "2.1.3",
               "bundled": true,
               "requires": {
-                "from2": "^1.3.0",
-                "stream-iterate": "^1.1.0"
+                "from2": "1.3.0",
+                "stream-iterate": "1.2.0"
               },
               "dependencies": {
                 "from2": {
                   "version": "1.3.0",
                   "bundled": true,
                   "requires": {
-                    "inherits": "~2.0.1",
-                    "readable-stream": "~1.1.10"
+                    "inherits": "2.0.3",
+                    "readable-stream": "1.1.14"
                   },
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.14",
                       "bundled": true,
                       "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -11193,8 +11193,8 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "readable-stream": "^2.1.5",
-                    "stream-shift": "^1.0.0"
+                    "readable-stream": "2.3.5",
+                    "stream-shift": "1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -11209,14 +11209,14 @@
               "version": "5.2.4",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.1"
               }
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -11229,33 +11229,33 @@
               "version": "4.4.0",
               "bundled": true,
               "requires": {
-                "chownr": "^1.0.1",
-                "fs-minipass": "^1.2.3",
-                "minipass": "^2.2.1",
-                "minizlib": "^1.1.0",
-                "mkdirp": "^0.5.0",
-                "yallist": "^3.0.2"
+                "chownr": "1.0.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.2.1",
+                "minizlib": "1.1.0",
+                "mkdirp": "0.5.1",
+                "yallist": "3.0.2"
               },
               "dependencies": {
                 "fs-minipass": {
                   "version": "1.2.5",
                   "bundled": true,
                   "requires": {
-                    "minipass": "^2.2.1"
+                    "minipass": "2.2.1"
                   }
                 },
                 "minipass": {
                   "version": "2.2.1",
                   "bundled": true,
                   "requires": {
-                    "yallist": "^3.0.0"
+                    "yallist": "3.0.2"
                   }
                 },
                 "minizlib": {
                   "version": "1.1.0",
                   "bundled": true,
                   "requires": {
-                    "minipass": "^2.2.1"
+                    "minipass": "2.2.1"
                   }
                 },
                 "yallist": {
@@ -11280,14 +11280,14 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "unique-slug": "^2.0.0"
+                "unique-slug": "2.0.0"
               },
               "dependencies": {
                 "unique-slug": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "imurmurhash": "^0.1.4"
+                    "imurmurhash": "0.1.4"
                   }
                 }
               }
@@ -11300,35 +11300,35 @@
               "version": "2.3.0",
               "bundled": true,
               "requires": {
-                "boxen": "^1.2.1",
-                "chalk": "^2.0.1",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-installed-globally": "^0.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
+                "boxen": "1.2.1",
+                "chalk": "2.1.0",
+                "configstore": "3.1.1",
+                "import-lazy": "2.1.0",
+                "is-installed-globally": "0.1.0",
+                "is-npm": "1.0.0",
+                "latest-version": "3.1.0",
+                "semver-diff": "2.1.0",
+                "xdg-basedir": "3.0.0"
               },
               "dependencies": {
                 "boxen": {
                   "version": "1.2.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-align": "^2.0.0",
-                    "camelcase": "^4.0.0",
-                    "chalk": "^2.0.1",
-                    "cli-boxes": "^1.0.0",
-                    "string-width": "^2.0.0",
-                    "term-size": "^1.2.0",
-                    "widest-line": "^1.0.0"
+                    "ansi-align": "2.0.0",
+                    "camelcase": "4.1.0",
+                    "chalk": "2.1.0",
+                    "cli-boxes": "1.0.0",
+                    "string-width": "2.1.1",
+                    "term-size": "1.2.0",
+                    "widest-line": "1.0.0"
                   },
                   "dependencies": {
                     "ansi-align": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "string-width": "^2.0.0"
+                        "string-width": "2.1.1"
                       }
                     },
                     "camelcase": {
@@ -11343,8 +11343,8 @@
                       "version": "2.1.1",
                       "bundled": true,
                       "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                       },
                       "dependencies": {
                         "is-fullwidth-code-point": {
@@ -11357,36 +11357,36 @@
                       "version": "1.2.0",
                       "bundled": true,
                       "requires": {
-                        "execa": "^0.7.0"
+                        "execa": "0.7.0"
                       },
                       "dependencies": {
                         "execa": {
                           "version": "0.7.0",
                           "bundled": true,
                           "requires": {
-                            "cross-spawn": "^5.0.1",
-                            "get-stream": "^3.0.0",
-                            "is-stream": "^1.1.0",
-                            "npm-run-path": "^2.0.0",
-                            "p-finally": "^1.0.0",
-                            "signal-exit": "^3.0.0",
-                            "strip-eof": "^1.0.0"
+                            "cross-spawn": "5.1.0",
+                            "get-stream": "3.0.0",
+                            "is-stream": "1.1.0",
+                            "npm-run-path": "2.0.2",
+                            "p-finally": "1.0.0",
+                            "signal-exit": "3.0.2",
+                            "strip-eof": "1.0.0"
                           },
                           "dependencies": {
                             "cross-spawn": {
                               "version": "5.1.0",
                               "bundled": true,
                               "requires": {
-                                "lru-cache": "^4.0.1",
-                                "shebang-command": "^1.2.0",
-                                "which": "^1.2.9"
+                                "lru-cache": "4.1.1",
+                                "shebang-command": "1.2.0",
+                                "which": "1.3.0"
                               },
                               "dependencies": {
                                 "shebang-command": {
                                   "version": "1.2.0",
                                   "bundled": true,
                                   "requires": {
-                                    "shebang-regex": "^1.0.0"
+                                    "shebang-regex": "1.0.0"
                                   },
                                   "dependencies": {
                                     "shebang-regex": {
@@ -11409,7 +11409,7 @@
                               "version": "2.0.2",
                               "bundled": true,
                               "requires": {
-                                "path-key": "^2.0.0"
+                                "path-key": "2.0.1"
                               },
                               "dependencies": {
                                 "path-key": {
@@ -11438,16 +11438,16 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "string-width": "^1.0.1"
+                        "string-width": "1.0.2"
                       },
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
                           "bundled": true,
                           "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
                           },
                           "dependencies": {
                             "code-point-at": {
@@ -11458,7 +11458,7 @@
                               "version": "1.0.0",
                               "bundled": true,
                               "requires": {
-                                "number-is-nan": "^1.0.0"
+                                "number-is-nan": "1.0.1"
                               },
                               "dependencies": {
                                 "number-is-nan": {
@@ -11471,7 +11471,7 @@
                               "version": "3.0.1",
                               "bundled": true,
                               "requires": {
-                                "ansi-regex": "^2.0.0"
+                                "ansi-regex": "2.1.1"
                               },
                               "dependencies": {
                                 "ansi-regex": {
@@ -11490,23 +11490,23 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "ansi-styles": "^3.1.0",
-                    "escape-string-regexp": "^1.0.5",
-                    "supports-color": "^4.0.0"
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.4.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
                       "version": "3.2.0",
                       "bundled": true,
                       "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.0"
                       },
                       "dependencies": {
                         "color-convert": {
                           "version": "1.9.0",
                           "bundled": true,
                           "requires": {
-                            "color-name": "^1.1.1"
+                            "color-name": "1.1.3"
                           },
                           "dependencies": {
                             "color-name": {
@@ -11525,7 +11525,7 @@
                       "version": "4.4.0",
                       "bundled": true,
                       "requires": {
-                        "has-flag": "^2.0.0"
+                        "has-flag": "2.0.0"
                       },
                       "dependencies": {
                         "has-flag": {
@@ -11540,19 +11540,19 @@
                   "version": "3.1.1",
                   "bundled": true,
                   "requires": {
-                    "dot-prop": "^4.1.0",
-                    "graceful-fs": "^4.1.2",
-                    "make-dir": "^1.0.0",
-                    "unique-string": "^1.0.0",
-                    "write-file-atomic": "^2.0.0",
-                    "xdg-basedir": "^3.0.0"
+                    "dot-prop": "4.2.0",
+                    "graceful-fs": "4.1.11",
+                    "make-dir": "1.0.0",
+                    "unique-string": "1.0.0",
+                    "write-file-atomic": "2.3.0",
+                    "xdg-basedir": "3.0.0"
                   },
                   "dependencies": {
                     "dot-prop": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "is-obj": "^1.0.0"
+                        "is-obj": "1.0.1"
                       },
                       "dependencies": {
                         "is-obj": {
@@ -11565,7 +11565,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "pify": "^2.3.0"
+                        "pify": "2.3.0"
                       },
                       "dependencies": {
                         "pify": {
@@ -11578,7 +11578,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "crypto-random-string": "^1.0.0"
+                        "crypto-random-string": "1.0.0"
                       },
                       "dependencies": {
                         "crypto-random-string": {
@@ -11597,22 +11597,22 @@
                   "version": "0.1.0",
                   "bundled": true,
                   "requires": {
-                    "global-dirs": "^0.1.0",
-                    "is-path-inside": "^1.0.0"
+                    "global-dirs": "0.1.0",
+                    "is-path-inside": "1.0.0"
                   },
                   "dependencies": {
                     "global-dirs": {
                       "version": "0.1.0",
                       "bundled": true,
                       "requires": {
-                        "ini": "^1.3.4"
+                        "ini": "1.3.5"
                       }
                     },
                     "is-path-inside": {
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "path-is-inside": "^1.0.1"
+                        "path-is-inside": "1.0.2"
                       }
                     }
                   }
@@ -11625,41 +11625,41 @@
                   "version": "3.1.0",
                   "bundled": true,
                   "requires": {
-                    "package-json": "^4.0.0"
+                    "package-json": "4.0.1"
                   },
                   "dependencies": {
                     "package-json": {
                       "version": "4.0.1",
                       "bundled": true,
                       "requires": {
-                        "got": "^6.7.1",
-                        "registry-auth-token": "^3.0.1",
-                        "registry-url": "^3.0.3",
-                        "semver": "^5.1.0"
+                        "got": "6.7.1",
+                        "registry-auth-token": "3.3.1",
+                        "registry-url": "3.1.0",
+                        "semver": "5.5.0"
                       },
                       "dependencies": {
                         "got": {
                           "version": "6.7.1",
                           "bundled": true,
                           "requires": {
-                            "create-error-class": "^3.0.0",
-                            "duplexer3": "^0.1.4",
-                            "get-stream": "^3.0.0",
-                            "is-redirect": "^1.0.0",
-                            "is-retry-allowed": "^1.0.0",
-                            "is-stream": "^1.0.0",
-                            "lowercase-keys": "^1.0.0",
-                            "safe-buffer": "^5.0.1",
-                            "timed-out": "^4.0.0",
-                            "unzip-response": "^2.0.1",
-                            "url-parse-lax": "^1.0.0"
+                            "create-error-class": "3.0.2",
+                            "duplexer3": "0.1.4",
+                            "get-stream": "3.0.0",
+                            "is-redirect": "1.0.0",
+                            "is-retry-allowed": "1.1.0",
+                            "is-stream": "1.1.0",
+                            "lowercase-keys": "1.0.0",
+                            "safe-buffer": "5.1.1",
+                            "timed-out": "4.0.1",
+                            "unzip-response": "2.0.1",
+                            "url-parse-lax": "1.0.0"
                           },
                           "dependencies": {
                             "create-error-class": {
                               "version": "3.0.2",
                               "bundled": true,
                               "requires": {
-                                "capture-stack-trace": "^1.0.0"
+                                "capture-stack-trace": "1.0.0"
                               },
                               "dependencies": {
                                 "capture-stack-trace": {
@@ -11704,7 +11704,7 @@
                               "version": "1.0.0",
                               "bundled": true,
                               "requires": {
-                                "prepend-http": "^1.0.1"
+                                "prepend-http": "1.0.4"
                               },
                               "dependencies": {
                                 "prepend-http": {
@@ -11719,18 +11719,18 @@
                           "version": "3.3.1",
                           "bundled": true,
                           "requires": {
-                            "rc": "^1.1.6",
-                            "safe-buffer": "^5.0.1"
+                            "rc": "1.2.1",
+                            "safe-buffer": "5.1.1"
                           },
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
                               "bundled": true,
                               "requires": {
-                                "deep-extend": "~0.4.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
+                                "deep-extend": "0.4.2",
+                                "ini": "1.3.5",
+                                "minimist": "1.2.0",
+                                "strip-json-comments": "2.0.1"
                               },
                               "dependencies": {
                                 "deep-extend": {
@@ -11753,17 +11753,17 @@
                           "version": "3.1.0",
                           "bundled": true,
                           "requires": {
-                            "rc": "^1.0.1"
+                            "rc": "1.2.1"
                           },
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
                               "bundled": true,
                               "requires": {
-                                "deep-extend": "~0.4.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
+                                "deep-extend": "0.4.2",
+                                "ini": "1.3.5",
+                                "minimist": "1.2.0",
+                                "strip-json-comments": "2.0.1"
                               },
                               "dependencies": {
                                 "deep-extend": {
@@ -11790,7 +11790,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "semver": "^5.0.3"
+                    "semver": "5.5.0"
                   }
                 },
                 "xdg-basedir": {
@@ -11807,15 +11807,15 @@
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "spdx-correct": "~1.0.0",
-                "spdx-expression-parse": "~1.0.0"
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
               },
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "spdx-license-ids": "^1.0.2"
+                    "spdx-license-ids": "1.2.2"
                   },
                   "dependencies": {
                     "spdx-license-ids": {
@@ -11834,7 +11834,7 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "builtins": "^1.0.3"
+                "builtins": "1.0.3"
               },
               "dependencies": {
                 "builtins": {
@@ -11847,7 +11847,7 @@
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
               },
               "dependencies": {
                 "isexe": {
@@ -11860,15 +11860,15 @@
               "version": "1.5.4",
               "bundled": true,
               "requires": {
-                "errno": "~0.1.7",
-                "xtend": "~4.0.1"
+                "errno": "0.1.7",
+                "xtend": "4.0.1"
               },
               "dependencies": {
                 "errno": {
                   "version": "0.1.7",
                   "bundled": true,
                   "requires": {
-                    "prr": "~1.0.1"
+                    "prr": "1.0.1"
                   },
                   "dependencies": {
                     "prr": {
@@ -11891,9 +11891,9 @@
               "version": "2.3.0",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.2"
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "signal-exit": "3.0.2"
               },
               "dependencies": {
                 "signal-exit": {
@@ -11911,19 +11911,19 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-1.6.44.tgz",
       "integrity": "sha1-OX5T4pYuXh3IcECGEKrX1tLWTLg=",
       "requires": {
-        "async": "^2.1.2",
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.5.0",
-        "imagemin": "^5.2.2",
+        "async": "2.6.0",
+        "babel-runtime": "6.26.0",
+        "bluebird": "3.5.1",
+        "imagemin": "5.3.1",
         "imagemin-pngquant": "5.0.1",
-        "imagemin-webp": "^4.0.0",
-        "lodash": "^4.17.4",
-        "mini-svg-data-uri": "^1.0.0",
-        "potrace": "^2.1.1",
-        "probe-image-size": "^4.0.0",
-        "progress": "^1.1.8",
-        "sharp": "^0.20.0",
-        "svgo": "^0.7.2"
+        "imagemin-webp": "4.1.0",
+        "lodash": "4.17.10",
+        "mini-svg-data-uri": "1.0.0",
+        "potrace": "2.1.1",
+        "probe-image-size": "4.0.0",
+        "progress": "1.1.8",
+        "sharp": "0.20.2",
+        "svgo": "0.7.2"
       }
     },
     "gatsby-plugin-sitemap": {
@@ -11931,9 +11931,9 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-1.2.23.tgz",
       "integrity": "sha1-gbcm90miH3mVWYErqhrQ/dsE5ms=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "minimatch": "^3.0.4",
-        "sitemap": "^1.12.0"
+        "babel-runtime": "6.26.0",
+        "minimatch": "3.0.4",
+        "sitemap": "1.13.0"
       },
       "dependencies": {
         "minimatch": {
@@ -11941,7 +11941,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -11951,7 +11951,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-styled-components/-/gatsby-plugin-styled-components-2.0.11.tgz",
       "integrity": "sha1-w9NDjHlwu8wRboIfuWZocJi9r1c=",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "gatsby-plugin-twitter": {
@@ -11959,7 +11959,7 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-twitter/-/gatsby-plugin-twitter-1.0.20.tgz",
       "integrity": "sha1-1phTlaUceAOh+zXp7wUHmFUcvqU=",
       "requires": {
-        "babel-runtime": "^6.26.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "gatsby-react-router-scroll": {
@@ -11967,9 +11967,9 @@
       "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-1.0.17.tgz",
       "integrity": "sha1-FrnGfaf0qZfruMeE9P66KyOvT5g=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "scroll-behavior": "^0.9.9",
-        "warning": "^3.0.0"
+        "babel-runtime": "6.26.0",
+        "scroll-behavior": "0.9.9",
+        "warning": "3.0.0"
       }
     },
     "gatsby-remark-autolink-headers": {
@@ -11977,10 +11977,10 @@
       "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-1.4.18.tgz",
       "integrity": "sha1-fxU2s8Z7MtkC2lzZbMLehjuMH28=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "github-slugger": "^1.1.1",
-        "mdast-util-to-string": "^1.0.2",
-        "unist-util-visit": "^1.1.1"
+        "babel-runtime": "6.26.0",
+        "github-slugger": "1.2.0",
+        "mdast-util-to-string": "1.0.4",
+        "unist-util-visit": "1.3.1"
       }
     },
     "gatsby-remark-copy-images": {
@@ -11988,10 +11988,10 @@
       "resolved": "https://registry.npmjs.org/gatsby-remark-copy-images/-/gatsby-remark-copy-images-0.2.1.tgz",
       "integrity": "sha512-V7VYWDrF8g3Chg1fvs4ztQHVdX3ZQ+9MsJplBKx4OLxEFOFolGNjyMz/bBTnIYX98QRLoY/9onEJD+yOzpMXig==",
       "requires": {
-        "fs-extra": "^1.0.0",
-        "is-relative-url": "^2.0.0",
-        "lodash": "^4.17.4",
-        "unist-util-visit": "^1.1.1"
+        "fs-extra": "1.0.0",
+        "is-relative-url": "2.0.0",
+        "lodash": "4.17.10",
+        "unist-util-visit": "1.3.1"
       },
       "dependencies": {
         "fs-extra": {
@@ -11999,9 +11999,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1"
           }
         },
         "jsonfile": {
@@ -12009,7 +12009,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         }
       }
@@ -12019,14 +12019,14 @@
       "resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-1.5.32.tgz",
       "integrity": "sha1-zFRDdxDVw8FTwvaBrc1If0aKv9E=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "cheerio": "^1.0.0-rc.2",
-        "fs-extra": "^4.0.1",
-        "is-relative-url": "^2.0.0",
-        "lodash": "^4.17.4",
-        "path-is-inside": "^1.0.2",
-        "probe-image-size": "^4.0.0",
-        "unist-util-visit": "^1.1.1"
+        "babel-runtime": "6.26.0",
+        "cheerio": "1.0.0-rc.2",
+        "fs-extra": "4.0.3",
+        "is-relative-url": "2.0.0",
+        "lodash": "4.17.10",
+        "path-is-inside": "1.0.2",
+        "probe-image-size": "4.0.0",
+        "unist-util-visit": "1.3.1"
       },
       "dependencies": {
         "cheerio": {
@@ -12034,12 +12034,12 @@
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
           "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
           "requires": {
-            "css-select": "~1.2.0",
-            "dom-serializer": "~0.1.0",
-            "entities": "~1.1.1",
-            "htmlparser2": "^3.9.1",
-            "lodash": "^4.15.0",
-            "parse5": "^3.0.1"
+            "css-select": "1.2.0",
+            "dom-serializer": "0.1.0",
+            "entities": "1.1.1",
+            "htmlparser2": "3.9.2",
+            "lodash": "4.17.10",
+            "parse5": "3.0.3"
           }
         },
         "domhandler": {
@@ -12047,7 +12047,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "htmlparser2": {
@@ -12055,12 +12055,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.2",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         }
       }
@@ -12070,13 +12070,13 @@
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-1.5.63.tgz",
       "integrity": "sha1-Dd/TvNM4YSl0kCTW3biBeLh0IvI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "cheerio": "^1.0.0-rc.2",
-        "gatsby-plugin-sharp": "^1.6.44",
-        "is-relative-url": "^2.0.0",
-        "lodash": "^4.17.4",
-        "slash": "^1.0.0",
-        "unist-util-select": "^1.5.0"
+        "babel-runtime": "6.26.0",
+        "cheerio": "1.0.0-rc.2",
+        "gatsby-plugin-sharp": "1.6.44",
+        "is-relative-url": "2.0.0",
+        "lodash": "4.17.10",
+        "slash": "1.0.0",
+        "unist-util-select": "1.5.0"
       },
       "dependencies": {
         "cheerio": {
@@ -12084,12 +12084,12 @@
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
           "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
           "requires": {
-            "css-select": "~1.2.0",
-            "dom-serializer": "~0.1.0",
-            "entities": "~1.1.1",
-            "htmlparser2": "^3.9.1",
-            "lodash": "^4.15.0",
-            "parse5": "^3.0.1"
+            "css-select": "1.2.0",
+            "dom-serializer": "0.1.0",
+            "entities": "1.1.1",
+            "htmlparser2": "3.9.2",
+            "lodash": "4.17.10",
+            "parse5": "3.0.3"
           }
         },
         "domhandler": {
@@ -12097,7 +12097,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "htmlparser2": {
@@ -12105,12 +12105,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.2",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         }
       }
@@ -12120,10 +12120,10 @@
       "resolved": "https://registry.npmjs.org/gatsby-remark-prismjs/-/gatsby-remark-prismjs-1.2.24.tgz",
       "integrity": "sha1-ssxOnE5xwI2Joy/YRyRPkn9Ke3k=",
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "babel-runtime": "6.26.0",
         "parse-numeric-range": "0.0.2",
-        "prismjs": "^1.12.2",
-        "unist-util-visit": "^1.3.0"
+        "prismjs": "1.14.0",
+        "unist-util-visit": "1.3.1"
       }
     },
     "gatsby-remark-responsive-iframe": {
@@ -12131,11 +12131,11 @@
       "resolved": "https://registry.npmjs.org/gatsby-remark-responsive-iframe/-/gatsby-remark-responsive-iframe-1.4.18.tgz",
       "integrity": "sha1-LI6xdMPbirdfh2muHTDFry4n3yI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.5.0",
-        "cheerio": "^1.0.0-rc.2",
-        "lodash": "^4.17.4",
-        "unist-util-visit": "^1.1.1"
+        "babel-runtime": "6.26.0",
+        "bluebird": "3.5.1",
+        "cheerio": "1.0.0-rc.2",
+        "lodash": "4.17.10",
+        "unist-util-visit": "1.3.1"
       },
       "dependencies": {
         "cheerio": {
@@ -12143,12 +12143,12 @@
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
           "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
           "requires": {
-            "css-select": "~1.2.0",
-            "dom-serializer": "~0.1.0",
-            "entities": "~1.1.1",
-            "htmlparser2": "^3.9.1",
-            "lodash": "^4.15.0",
-            "parse5": "^3.0.1"
+            "css-select": "1.2.0",
+            "dom-serializer": "0.1.0",
+            "entities": "1.1.1",
+            "htmlparser2": "3.9.2",
+            "lodash": "4.17.10",
+            "parse5": "3.0.3"
           }
         },
         "domhandler": {
@@ -12156,7 +12156,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "htmlparser2": {
@@ -12164,12 +12164,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.2",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         }
       }
@@ -12179,18 +12179,18 @@
       "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-1.5.35.tgz",
       "integrity": "sha1-HXqSxg3vG6b38zxGjPSDKvDpBO0=",
       "requires": {
-        "babel-cli": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "better-queue": "^3.8.7",
-        "bluebird": "^3.5.0",
-        "chokidar": "^1.7.0",
-        "fs-extra": "^4.0.1",
-        "got": "^7.1.0",
-        "md5-file": "^3.1.1",
-        "mime": "^1.3.6",
-        "pretty-bytes": "^4.0.2",
-        "slash": "^1.0.0",
-        "valid-url": "^1.0.9"
+        "babel-cli": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "better-queue": "3.8.7",
+        "bluebird": "3.5.1",
+        "chokidar": "1.7.0",
+        "fs-extra": "4.0.3",
+        "got": "7.1.0",
+        "md5-file": "3.2.3",
+        "mime": "1.6.0",
+        "pretty-bytes": "4.0.2",
+        "slash": "1.0.0",
+        "valid-url": "1.0.9"
       },
       "dependencies": {
         "got": {
@@ -12198,20 +12198,20 @@
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "requires": {
-            "decompress-response": "^3.2.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "p-cancelable": "^0.3.0",
-            "p-timeout": "^1.1.1",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "url-parse-lax": "^1.0.0",
-            "url-to-options": "^1.0.1"
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-plain-obj": "1.1.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "isurl": "1.0.0",
+            "lowercase-keys": "1.0.1",
+            "p-cancelable": "0.3.0",
+            "p-timeout": "1.2.1",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "url-parse-lax": "1.0.0",
+            "url-to-options": "1.0.1"
           }
         }
       }
@@ -12221,26 +12221,26 @@
       "resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-1.7.41.tgz",
       "integrity": "sha1-v94pKgZdMGwk5dMD7CjqJHhvCW4=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "bluebird": "^3.5.0",
-        "graphql-type-json": "^0.1.4",
-        "gray-matter": "^3.0.0",
-        "hast-util-raw": "^2.0.2",
-        "hast-util-to-html": "^3.0.0",
-        "lodash": "^4.17.4",
-        "mdast-util-to-hast": "^2.4.0",
-        "mdast-util-toc": "^2.0.1",
-        "remark": "^7.0.1",
-        "remark-parse": "^4.0.0",
-        "remark-retext": "^3.1.0",
-        "remark-stringify": "^4.0.0",
-        "retext-english": "^3.0.0",
-        "sanitize-html": "^1.14.1",
-        "underscore.string": "^3.3.4",
-        "unified": "^6.1.5",
-        "unist-util-remove-position": "^1.1.1",
-        "unist-util-select": "^1.5.0",
-        "unist-util-visit": "^1.1.1"
+        "babel-runtime": "6.26.0",
+        "bluebird": "3.5.1",
+        "graphql-type-json": "0.1.4",
+        "gray-matter": "3.1.1",
+        "hast-util-raw": "2.0.2",
+        "hast-util-to-html": "3.1.0",
+        "lodash": "4.17.10",
+        "mdast-util-to-hast": "2.5.0",
+        "mdast-util-toc": "2.0.1",
+        "remark": "7.0.1",
+        "remark-parse": "4.0.0",
+        "remark-retext": "3.1.0",
+        "remark-stringify": "4.0.0",
+        "retext-english": "3.0.0",
+        "sanitize-html": "1.18.2",
+        "underscore.string": "3.3.4",
+        "unified": "6.2.0",
+        "unist-util-remove-position": "1.1.2",
+        "unist-util-select": "1.5.0",
+        "unist-util-visit": "1.3.1"
       }
     },
     "gauge": {
@@ -12248,11 +12248,11 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
       "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
       "requires": {
-        "ansi": "^0.3.0",
-        "has-unicode": "^2.0.0",
-        "lodash.pad": "^4.1.0",
-        "lodash.padend": "^4.1.0",
-        "lodash.padstart": "^4.1.0"
+        "ansi": "0.3.1",
+        "has-unicode": "2.0.1",
+        "lodash.pad": "4.5.1",
+        "lodash.padend": "4.6.1",
+        "lodash.padstart": "4.6.1"
       }
     },
     "gaze": {
@@ -12261,7 +12261,7 @@
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "dev": true,
       "requires": {
-        "globule": "~0.1.0"
+        "globule": "0.1.0"
       }
     },
     "generate-function": {
@@ -12276,7 +12276,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "get-caller-file": {
@@ -12299,7 +12299,7 @@
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
       "requires": {
-        "rc": "^1.1.2"
+        "rc": "1.2.7"
       }
     },
     "get-stdin": {
@@ -12322,7 +12322,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "gh-pages": {
@@ -12332,12 +12332,12 @@
       "dev": true,
       "requires": {
         "async": "2.6.0",
-        "base64url": "^2.0.0",
+        "base64url": "2.0.0",
         "commander": "2.11.0",
-        "fs-extra": "^4.0.2",
-        "globby": "^6.1.0",
+        "fs-extra": "4.0.3",
+        "globby": "6.1.0",
         "graceful-fs": "4.1.11",
-        "rimraf": "^2.6.2"
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "commander": {
@@ -12358,7 +12358,7 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.0.tgz",
       "integrity": "sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==",
       "requires": {
-        "emoji-regex": ">=6.0.0 <=6.1.1"
+        "emoji-regex": "6.1.1"
       }
     },
     "glob": {
@@ -12366,12 +12366,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       },
       "dependencies": {
         "minimatch": {
@@ -12379,7 +12379,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -12389,8 +12389,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -12398,7 +12398,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob-stream": {
@@ -12406,14 +12406,14 @@
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "requires": {
-        "extend": "^3.0.0",
-        "glob": "^5.0.3",
-        "glob-parent": "^3.0.0",
-        "micromatch": "^2.3.7",
-        "ordered-read-streams": "^0.3.0",
-        "through2": "^0.6.0",
-        "to-absolute-glob": "^0.1.1",
-        "unique-stream": "^2.0.2"
+        "extend": "3.0.1",
+        "glob": "5.0.15",
+        "glob-parent": "3.1.0",
+        "micromatch": "2.3.11",
+        "ordered-read-streams": "0.3.0",
+        "through2": "0.6.5",
+        "to-absolute-glob": "0.1.1",
+        "unique-stream": "2.2.1"
       },
       "dependencies": {
         "glob": {
@@ -12421,11 +12421,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-parent": {
@@ -12433,8 +12433,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "is-extglob": {
@@ -12447,7 +12447,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "isarray": {
@@ -12460,7 +12460,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "readable-stream": {
@@ -12468,10 +12468,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -12484,8 +12484,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -12501,7 +12501,7 @@
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "dev": true,
       "requires": {
-        "gaze": "^0.5.1"
+        "gaze": "0.5.2"
       }
     },
     "glob2base": {
@@ -12510,7 +12510,7 @@
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "requires": {
-        "find-index": "^0.1.1"
+        "find-index": "0.1.1"
       }
     },
     "global": {
@@ -12518,8 +12518,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "min-document": "2.19.0",
+        "process": "0.5.2"
       },
       "dependencies": {
         "process": {
@@ -12534,7 +12534,7 @@
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
     "global-modules": {
@@ -12542,9 +12542,9 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -12552,11 +12552,11 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.0"
       },
       "dependencies": {
         "expand-tilde": {
@@ -12564,7 +12564,7 @@
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.1"
           }
         }
       }
@@ -12579,11 +12579,11 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pify": {
@@ -12605,9 +12605,9 @@
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
       "requires": {
-        "glob": "~3.1.21",
-        "lodash": "~1.0.1",
-        "minimatch": "~0.2.11"
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
       },
       "dependencies": {
         "glob": {
@@ -12616,9 +12616,9 @@
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
           }
         },
         "graceful-fs": {
@@ -12651,8 +12651,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         }
       }
@@ -12662,7 +12662,7 @@
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "gonzales-pe": {
@@ -12671,7 +12671,7 @@
       "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
       "dev": true,
       "requires": {
-        "minimist": "1.1.x"
+        "minimist": "1.1.3"
       },
       "dependencies": {
         "minimist": {
@@ -12688,7 +12688,7 @@
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "optional": true,
       "requires": {
-        "delegate": "^3.1.2"
+        "delegate": "3.2.0"
       }
     },
     "got": {
@@ -12696,17 +12696,17 @@
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -12737,8 +12737,8 @@
       "resolved": "https://registry.npmjs.org/graphql-skip-limit/-/graphql-skip-limit-1.0.11.tgz",
       "integrity": "sha1-xpcNEb3+eqAB+WyLpBuak6bcgFw=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "graphql": "^0.11.7"
+        "babel-runtime": "6.26.0",
+        "graphql": "0.11.7"
       }
     },
     "graphql-type-json": {
@@ -12751,10 +12751,10 @@
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.1.1.tgz",
       "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "js-yaml": "^3.10.0",
-        "kind-of": "^5.0.2",
-        "strip-bom-string": "^1.0.0"
+        "extend-shallow": "2.0.1",
+        "js-yaml": "3.11.0",
+        "kind-of": "5.1.0",
+        "strip-bom-string": "1.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -12767,7 +12767,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "js-yaml": {
@@ -12775,8 +12775,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
           "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
           }
         },
         "kind-of": {
@@ -12792,19 +12792,19 @@
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "chalk": "^1.0.0",
-        "deprecated": "^0.0.1",
-        "gulp-util": "^3.0.0",
-        "interpret": "^1.0.0",
-        "liftoff": "^2.1.0",
-        "minimist": "^1.1.0",
-        "orchestrator": "^0.3.0",
-        "pretty-hrtime": "^1.0.0",
-        "semver": "^4.1.0",
-        "tildify": "^1.0.0",
-        "v8flags": "^2.0.2",
-        "vinyl-fs": "^0.3.0"
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.1.0",
+        "liftoff": "2.5.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
       },
       "dependencies": {
         "clone": {
@@ -12819,10 +12819,10 @@
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
           }
         },
         "glob-stream": {
@@ -12831,12 +12831,12 @@
           "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
           "dev": true,
           "requires": {
-            "glob": "^4.3.1",
-            "glob2base": "^0.0.12",
-            "minimatch": "^2.0.1",
-            "ordered-read-streams": "^0.1.0",
-            "through2": "^0.6.1",
-            "unique-stream": "^1.0.0"
+            "glob": "4.5.3",
+            "glob2base": "0.0.12",
+            "minimatch": "2.0.10",
+            "ordered-read-streams": "0.1.0",
+            "through2": "0.6.5",
+            "unique-stream": "1.0.0"
           }
         },
         "graceful-fs": {
@@ -12845,7 +12845,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "^1.1.0"
+            "natives": "1.1.3"
           }
         },
         "interpret": {
@@ -12872,10 +12872,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "semver": {
@@ -12896,8 +12896,8 @@
           "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
           "dev": true,
           "requires": {
-            "first-chunk-stream": "^1.0.0",
-            "is-utf8": "^0.2.0"
+            "first-chunk-stream": "1.0.0",
+            "is-utf8": "0.2.1"
           }
         },
         "through2": {
@@ -12906,8 +12906,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         },
         "unique-stream": {
@@ -12922,8 +12922,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         },
         "vinyl-fs": {
@@ -12932,14 +12932,14 @@
           "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
           "dev": true,
           "requires": {
-            "defaults": "^1.0.0",
-            "glob-stream": "^3.1.5",
-            "glob-watcher": "^0.0.6",
-            "graceful-fs": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "strip-bom": "^1.0.0",
-            "through2": "^0.6.1",
-            "vinyl": "^0.4.0"
+            "defaults": "1.0.3",
+            "glob-stream": "3.1.18",
+            "glob-watcher": "0.0.6",
+            "graceful-fs": "3.0.11",
+            "mkdirp": "0.5.1",
+            "strip-bom": "1.0.0",
+            "through2": "0.6.5",
+            "vinyl": "0.4.6"
           }
         }
       }
@@ -12950,9 +12950,9 @@
       "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
       "dev": true,
       "requires": {
-        "concat-with-sourcemaps": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^2.0.0"
+        "concat-with-sourcemaps": "1.1.0",
+        "through2": "2.0.3",
+        "vinyl": "2.1.0"
       },
       "dependencies": {
         "clone": {
@@ -12973,12 +12973,12 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -12988,10 +12988,10 @@
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
       "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
       "requires": {
-        "archive-type": "^3.0.0",
-        "decompress": "^3.0.0",
-        "gulp-util": "^3.0.1",
-        "readable-stream": "^2.0.2"
+        "archive-type": "3.2.0",
+        "decompress": "3.0.0",
+        "gulp-util": "3.0.8",
+        "readable-stream": "2.3.6"
       }
     },
     "gulp-front-matter": {
@@ -13000,12 +13000,12 @@
       "integrity": "sha1-XuRm+/r7M0ILzV4CZ7toGURKsG0=",
       "dev": true,
       "requires": {
-        "front-matter": "^2.0.0",
-        "gulp-util": "^3.0.6",
-        "object-path": "^0.9.2",
-        "readable-stream": "^2.0.3",
-        "tryit": "^1.0.1",
-        "vinyl-bufferstream": "^1.0.1"
+        "front-matter": "2.3.0",
+        "gulp-util": "3.0.8",
+        "object-path": "0.9.2",
+        "readable-stream": "2.3.6",
+        "tryit": "1.0.3",
+        "vinyl-bufferstream": "1.0.1"
       },
       "dependencies": {
         "object-path": {
@@ -13022,7 +13022,7 @@
       "integrity": "sha1-gMDqWKOqQ4KjLAWp1qcLHFZqgT0=",
       "dev": true,
       "requires": {
-        "findup-sync": "^0.2.1",
+        "findup-sync": "0.2.1",
         "multimatch": "2.0.0"
       },
       "dependencies": {
@@ -13032,7 +13032,7 @@
           "integrity": "sha1-4KkKRQB1xJRm7lE3MgV1FLgeh4w=",
           "dev": true,
           "requires": {
-            "glob": "~4.3.0"
+            "glob": "4.3.5"
           }
         },
         "glob": {
@@ -13041,10 +13041,10 @@
           "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
           }
         }
       }
@@ -13059,11 +13059,11 @@
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "requires": {
-        "convert-source-map": "^1.1.1",
-        "graceful-fs": "^4.1.2",
-        "strip-bom": "^2.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0"
+        "convert-source-map": "1.5.1",
+        "graceful-fs": "4.1.11",
+        "strip-bom": "2.0.0",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -13071,7 +13071,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -13082,10 +13082,10 @@
       "integrity": "sha1-AIgqj+AFLcm4ScaHCw/DmSaSpKY=",
       "dev": true,
       "requires": {
-        "gulp-util": "^2.2.14",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.2.6",
-        "through2": "^0.5.1"
+        "gulp-util": "2.2.20",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "through2": "0.5.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -13106,11 +13106,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
           }
         },
         "dateformat": {
@@ -13119,8 +13119,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.3.0"
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
           }
         },
         "gulp-util": {
@@ -13129,14 +13129,14 @@
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "dev": true,
           "requires": {
-            "chalk": "^0.5.0",
-            "dateformat": "^1.0.7-1.2.3",
-            "lodash._reinterpolate": "^2.4.1",
-            "lodash.template": "^2.4.1",
-            "minimist": "^0.2.0",
-            "multipipe": "^0.1.0",
-            "through2": "^0.5.0",
-            "vinyl": "^0.2.1"
+            "chalk": "0.5.1",
+            "dateformat": "1.0.12",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.template": "2.4.1",
+            "minimist": "0.2.0",
+            "multipipe": "0.1.2",
+            "through2": "0.5.1",
+            "vinyl": "0.2.3"
           }
         },
         "has-ansi": {
@@ -13145,7 +13145,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.0"
+            "ansi-regex": "0.2.1"
           }
         },
         "isarray": {
@@ -13166,8 +13166,8 @@
           "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
           "dev": true,
           "requires": {
-            "lodash._objecttypes": "~2.4.1",
-            "lodash.keys": "~2.4.1"
+            "lodash._objecttypes": "2.4.1",
+            "lodash.keys": "2.4.1"
           }
         },
         "lodash.escape": {
@@ -13176,9 +13176,9 @@
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
           "dev": true,
           "requires": {
-            "lodash._escapehtmlchar": "~2.4.1",
-            "lodash._reunescapedhtml": "~2.4.1",
-            "lodash.keys": "~2.4.1"
+            "lodash._escapehtmlchar": "2.4.1",
+            "lodash._reunescapedhtml": "2.4.1",
+            "lodash.keys": "2.4.1"
           }
         },
         "lodash.keys": {
@@ -13187,9 +13187,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         },
         "lodash.template": {
@@ -13198,13 +13198,13 @@
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
           "dev": true,
           "requires": {
-            "lodash._escapestringchar": "~2.4.1",
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.defaults": "~2.4.1",
-            "lodash.escape": "~2.4.1",
-            "lodash.keys": "~2.4.1",
-            "lodash.templatesettings": "~2.4.1",
-            "lodash.values": "~2.4.1"
+            "lodash._escapestringchar": "2.4.1",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.defaults": "2.4.1",
+            "lodash.escape": "2.4.1",
+            "lodash.keys": "2.4.1",
+            "lodash.templatesettings": "2.4.1",
+            "lodash.values": "2.4.1"
           }
         },
         "lodash.templatesettings": {
@@ -13213,8 +13213,8 @@
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.escape": "~2.4.1"
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.escape": "2.4.1"
           }
         },
         "minimist": {
@@ -13229,10 +13229,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -13247,7 +13247,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.1"
+            "ansi-regex": "0.2.1"
           }
         },
         "supports-color": {
@@ -13262,8 +13262,8 @@
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~3.0.0"
+            "readable-stream": "1.0.34",
+            "xtend": "3.0.0"
           }
         },
         "vinyl": {
@@ -13272,7 +13272,7 @@
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
           "dev": true,
           "requires": {
-            "clone-stats": "~0.0.1"
+            "clone-stats": "0.0.1"
           }
         },
         "xtend": {
@@ -13288,24 +13288,24 @@
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
       },
       "dependencies": {
         "lodash.template": {
@@ -13313,15 +13313,15 @@
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
           "requires": {
-            "lodash._basecopy": "^3.0.0",
-            "lodash._basetostring": "^3.0.0",
-            "lodash._basevalues": "^3.0.0",
-            "lodash._isiterateecall": "^3.0.0",
-            "lodash._reinterpolate": "^3.0.0",
-            "lodash.escape": "^3.0.0",
-            "lodash.keys": "^3.0.0",
-            "lodash.restparam": "^3.0.0",
-            "lodash.templatesettings": "^3.0.0"
+            "lodash._basecopy": "3.0.1",
+            "lodash._basetostring": "3.0.1",
+            "lodash._basevalues": "3.0.0",
+            "lodash._isiterateecall": "3.0.9",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.2.0",
+            "lodash.keys": "3.1.2",
+            "lodash.restparam": "3.6.1",
+            "lodash.templatesettings": "3.1.1"
           }
         },
         "lodash.templatesettings": {
@@ -13329,8 +13329,8 @@
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
           "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
           "requires": {
-            "lodash._reinterpolate": "^3.0.0",
-            "lodash.escape": "^3.0.0"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.2.0"
           }
         },
         "object-assign": {
@@ -13348,8 +13348,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -13360,16 +13360,16 @@
       "resolved": "https://registry.npmjs.org/gulp-watch/-/gulp-watch-5.0.0.tgz",
       "integrity": "sha512-q+HLppxXd11z9ndqql4Z0sd5xOAesJjycl0PRaq6ImK7b1BqBRL37YvxEE8ngUdIfpfHa0O9OCoovoggcFpCaQ==",
       "requires": {
-        "anymatch": "^1.3.0",
-        "chokidar": "^2.0.0",
-        "glob-parent": "^3.0.1",
-        "gulp-util": "^3.0.7",
-        "object-assign": "^4.1.0",
-        "path-is-absolute": "^1.0.1",
-        "readable-stream": "^2.2.2",
-        "slash": "^1.0.0",
-        "vinyl": "^2.1.0",
-        "vinyl-file": "^2.0.0"
+        "anymatch": "1.3.2",
+        "chokidar": "2.0.3",
+        "glob-parent": "3.1.0",
+        "gulp-util": "3.0.8",
+        "object-assign": "4.1.1",
+        "path-is-absolute": "1.0.1",
+        "readable-stream": "2.3.6",
+        "slash": "1.0.0",
+        "vinyl": "2.1.0",
+        "vinyl-file": "2.0.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -13387,16 +13387,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -13404,7 +13404,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -13414,18 +13414,18 @@
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
           "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
           "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.0",
-            "braces": "^2.3.0",
-            "fsevents": "^1.1.2",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^2.1.1",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0",
-            "upath": "^1.0.0"
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.2",
+            "fsevents": "1.2.3",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0",
+            "upath": "1.0.5"
           },
           "dependencies": {
             "anymatch": {
@@ -13433,8 +13433,8 @@
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
               "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
               "requires": {
-                "micromatch": "^3.1.4",
-                "normalize-path": "^2.1.1"
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
               }
             }
           }
@@ -13454,13 +13454,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -13468,7 +13468,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -13476,7 +13476,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -13484,7 +13484,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -13492,7 +13492,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -13502,7 +13502,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -13510,7 +13510,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -13520,9 +13520,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -13537,14 +13537,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -13552,7 +13552,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -13560,7 +13560,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -13570,10 +13570,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -13581,7 +13581,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -13591,8 +13591,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -13600,7 +13600,7 @@
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -13610,7 +13610,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -13618,7 +13618,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -13626,9 +13626,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -13641,7 +13641,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -13649,7 +13649,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13657,7 +13657,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -13677,19 +13677,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "vinyl": {
@@ -13697,12 +13697,12 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -13712,7 +13712,7 @@
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "gzip-size": {
@@ -13720,7 +13720,7 @@
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
       "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
       "requires": {
-        "duplexer": "^0.1.1"
+        "duplexer": "0.1.1"
       }
     },
     "handlebars": {
@@ -13728,10 +13728,10 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "async": {
@@ -13744,7 +13744,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -13759,8 +13759,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -13768,7 +13768,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -13776,7 +13776,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
@@ -13809,7 +13809,7 @@
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "has-symbol-support-x": {
@@ -13828,7 +13828,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-unicode": {
@@ -13841,9 +13841,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -13858,8 +13858,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -13867,7 +13867,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -13875,7 +13875,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -13885,7 +13885,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -13895,8 +13895,8 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "hash.js": {
@@ -13904,8 +13904,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "hast-to-hyperscript": {
@@ -13913,13 +13913,13 @@
       "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-3.1.0.tgz",
       "integrity": "sha512-/At2y6sQLTAcL6y+3hRQFcaBoRlKrmHSpvvdOZqRz6uI2YyjrU8rJ7e1LbmLtWUmzaIqKEdNSku+AJC0pt4+aw==",
       "requires": {
-        "comma-separated-tokens": "^1.0.0",
-        "is-nan": "^1.2.1",
-        "kebab-case": "^1.0.0",
-        "property-information": "^3.0.0",
-        "space-separated-tokens": "^1.0.0",
+        "comma-separated-tokens": "1.0.5",
+        "is-nan": "1.2.1",
+        "kebab-case": "1.0.0",
+        "property-information": "3.2.0",
+        "space-separated-tokens": "1.1.2",
         "trim": "0.0.1",
-        "unist-util-is": "^2.0.0"
+        "unist-util-is": "2.1.2"
       }
     },
     "hast-util-from-parse5": {
@@ -13927,10 +13927,10 @@
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-2.1.0.tgz",
       "integrity": "sha1-9hI9g9NoljCwl+E+Qw0W2dG9iIQ=",
       "requires": {
-        "camelcase": "^3.0.0",
-        "hastscript": "^3.0.0",
-        "property-information": "^3.1.0",
-        "vfile-location": "^2.0.0"
+        "camelcase": "3.0.0",
+        "hastscript": "3.1.0",
+        "property-information": "3.2.0",
+        "vfile-location": "2.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -13955,13 +13955,13 @@
       "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-2.0.2.tgz",
       "integrity": "sha512-ujytXSAZC85bvh38f8ALzfE2IZDdCwB9XeHUs9l20C1p4/1YeAoZqq9z9U17vWQ9hMmqbVaROuSK8feL3wTCJg==",
       "requires": {
-        "hast-util-from-parse5": "^2.0.0",
-        "hast-util-to-parse5": "^2.0.0",
-        "html-void-elements": "^1.0.1",
-        "parse5": "^3.0.3",
-        "unist-util-position": "^3.0.0",
-        "web-namespaces": "^1.0.0",
-        "zwitch": "^1.0.0"
+        "hast-util-from-parse5": "2.1.0",
+        "hast-util-to-parse5": "2.2.0",
+        "html-void-elements": "1.0.3",
+        "parse5": "3.0.3",
+        "unist-util-position": "3.0.1",
+        "web-namespaces": "1.1.2",
+        "zwitch": "1.0.3"
       }
     },
     "hast-util-to-html": {
@@ -13969,17 +13969,17 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-3.1.0.tgz",
       "integrity": "sha1-iCyZhJ5AEw6ZHAQuRW1FPZXDbP8=",
       "requires": {
-        "ccount": "^1.0.0",
-        "comma-separated-tokens": "^1.0.1",
-        "hast-util-is-element": "^1.0.0",
-        "hast-util-whitespace": "^1.0.0",
-        "html-void-elements": "^1.0.0",
-        "kebab-case": "^1.0.0",
-        "property-information": "^3.1.0",
-        "space-separated-tokens": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unist-util-is": "^2.0.0",
-        "xtend": "^4.0.1"
+        "ccount": "1.0.3",
+        "comma-separated-tokens": "1.0.5",
+        "hast-util-is-element": "1.0.0",
+        "hast-util-whitespace": "1.0.0",
+        "html-void-elements": "1.0.3",
+        "kebab-case": "1.0.0",
+        "property-information": "3.2.0",
+        "space-separated-tokens": "1.1.2",
+        "stringify-entities": "1.3.2",
+        "unist-util-is": "2.1.2",
+        "xtend": "4.0.1"
       }
     },
     "hast-util-to-parse5": {
@@ -13987,11 +13987,11 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-2.2.0.tgz",
       "integrity": "sha512-Eg1mrf0VTT/PipFN5z1+mVi+4GNhinKk/i/HKeX1h17IYiMdm3G8vgA0FU04XCuD1cWV58f5zziFKcBkr+WuKw==",
       "requires": {
-        "hast-to-hyperscript": "^3.0.0",
-        "mapz": "^1.0.0",
-        "web-namespaces": "^1.0.0",
-        "xtend": "^4.0.1",
-        "zwitch": "^1.0.0"
+        "hast-to-hyperscript": "3.1.0",
+        "mapz": "1.0.2",
+        "web-namespaces": "1.1.2",
+        "xtend": "4.0.1",
+        "zwitch": "1.0.3"
       }
     },
     "hast-util-whitespace": {
@@ -14004,11 +14004,11 @@
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-3.1.0.tgz",
       "integrity": "sha512-8V34dMSDT1Ik+ZSgTzCLdyp89MrWxcxctXPxhmb72GQj1Xkw1aHPM9UaHCWewvH2Q+PVkYUm4ZJVw4T0dgEGNA==",
       "requires": {
-        "camelcase": "^3.0.0",
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^3.0.0",
-        "space-separated-tokens": "^1.0.0"
+        "camelcase": "3.0.0",
+        "comma-separated-tokens": "1.0.5",
+        "hast-util-parse-selector": "2.1.0",
+        "property-information": "3.2.0",
+        "space-separated-tokens": "1.1.2"
       },
       "dependencies": {
         "camelcase": {
@@ -14023,10 +14023,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
       }
     },
     "he": {
@@ -14040,11 +14040,11 @@
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
       "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
       "requires": {
-        "invariant": "^2.2.1",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^2.2.0",
-        "value-equal": "^0.4.0",
-        "warning": "^3.0.0"
+        "invariant": "2.2.4",
+        "loose-envify": "1.3.1",
+        "resolve-pathname": "2.2.0",
+        "value-equal": "0.4.0",
+        "warning": "3.0.0"
       }
     },
     "hmac-drbg": {
@@ -14052,9 +14052,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
@@ -14072,8 +14072,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "homedir-polyfill": {
@@ -14081,7 +14081,7 @@
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -14115,10 +14115,10 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
       "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.1",
-        "domutils": "1.1",
-        "readable-stream": "1.0"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.1.0",
+        "domutils": "1.1.6",
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "domutils": {
@@ -14126,7 +14126,7 @@
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "isarray": {
@@ -14139,10 +14139,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -14157,10 +14157,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.4.0"
       }
     },
     "http-parser-js": {
@@ -14173,9 +14173,9 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "requires": {
-        "eventemitter3": "^3.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.4.1",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -14183,10 +14183,10 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "requires": {
-        "http-proxy": "^1.16.2",
-        "is-glob": "^3.1.0",
-        "lodash": "^4.17.2",
-        "micromatch": "^2.3.11"
+        "http-proxy": "1.17.0",
+        "is-glob": "3.1.0",
+        "lodash": "4.17.10",
+        "micromatch": "2.3.11"
       },
       "dependencies": {
         "is-extglob": {
@@ -14199,7 +14199,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -14209,9 +14209,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "https-browserify": {
@@ -14245,12 +14245,12 @@
       "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-5.3.1.tgz",
       "integrity": "sha1-8Zwu7h5xumxlWMUV+fyWaAGJptQ=",
       "requires": {
-        "file-type": "^4.1.0",
-        "globby": "^6.1.0",
-        "make-dir": "^1.0.0",
-        "p-pipe": "^1.1.0",
-        "pify": "^2.3.0",
-        "replace-ext": "^1.0.0"
+        "file-type": "4.4.0",
+        "globby": "6.1.0",
+        "make-dir": "1.3.0",
+        "p-pipe": "1.2.0",
+        "pify": "2.3.0",
+        "replace-ext": "1.0.0"
       },
       "dependencies": {
         "pify": {
@@ -14265,9 +14265,9 @@
       "resolved": "https://registry.npmjs.org/imagemin-pngquant/-/imagemin-pngquant-5.0.1.tgz",
       "integrity": "sha1-2KMp2lU6+iJrEc5i3r4Lfje0OeY=",
       "requires": {
-        "exec-buffer": "^3.0.0",
-        "is-png": "^1.0.0",
-        "pngquant-bin": "^3.0.0"
+        "exec-buffer": "3.2.0",
+        "is-png": "1.1.0",
+        "pngquant-bin": "3.1.1"
       }
     },
     "imagemin-webp": {
@@ -14275,9 +14275,9 @@
       "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-4.1.0.tgz",
       "integrity": "sha1-7/0AFg2EVrlcveX9JsMtZLAxgGI=",
       "requires": {
-        "cwebp-bin": "^4.0.0",
-        "exec-buffer": "^3.0.0",
-        "is-cwebp-readable": "^2.0.1"
+        "cwebp-bin": "4.0.0",
+        "exec-buffer": "3.2.0",
+        "is-cwebp-readable": "2.0.1"
       }
     },
     "immutable": {
@@ -14300,7 +14300,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexes-of": {
@@ -14318,8 +14318,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -14337,20 +14337,20 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -14363,7 +14363,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14371,9 +14371,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -14386,7 +14386,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -14394,7 +14394,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14409,7 +14409,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "invert-kv": {
@@ -14437,7 +14437,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-mini/-/ipfs-mini-1.1.2.tgz",
       "integrity": "sha1-nA+tP6AKgsgsrtGuBLO5ntOz6V0=",
       "requires": {
-        "xmlhttprequest": "^1.8.0"
+        "xmlhttprequest": "1.8.0"
       }
     },
     "irregular-plurals": {
@@ -14451,8 +14451,8 @@
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       },
       "dependencies": {
         "is-relative": {
@@ -14460,7 +14460,7 @@
           "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
           "requires": {
-            "is-unc-path": "^1.0.0"
+            "is-unc-path": "1.0.0"
           }
         },
         "is-unc-path": {
@@ -14468,7 +14468,7 @@
           "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
           "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
           "requires": {
-            "unc-path-regex": "^0.1.2"
+            "unc-path-regex": "0.1.2"
           }
         }
       }
@@ -14483,7 +14483,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-alphabetical": {
@@ -14501,8 +14501,8 @@
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
       "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
       "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
+        "is-alphabetical": "1.0.2",
+        "is-decimal": "1.0.2"
       }
     },
     "is-arrayish": {
@@ -14515,7 +14515,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -14528,7 +14528,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-bzip2": {
@@ -14547,7 +14547,7 @@
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.3"
       }
     },
     "is-cwebp-readable": {
@@ -14555,7 +14555,7 @@
       "resolved": "https://registry.npmjs.org/is-cwebp-readable/-/is-cwebp-readable-2.0.1.tgz",
       "integrity": "sha1-r7k7DAq9CiUQEBauM66ort+SbSY=",
       "requires": {
-        "file-type": "^4.3.0"
+        "file-type": "4.4.0"
       }
     },
     "is-data-descriptor": {
@@ -14563,7 +14563,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-date-object": {
@@ -14582,9 +14582,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -14616,7 +14616,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-expression": {
@@ -14625,8 +14625,8 @@
       "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
       "dev": true,
       "requires": {
-        "acorn": "~4.0.2",
-        "object-assign": "^4.0.1"
+        "acorn": "4.0.13",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "acorn": {
@@ -14652,7 +14652,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -14670,7 +14670,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-gzip": {
@@ -14699,8 +14699,8 @@
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-integer": {
@@ -14709,7 +14709,7 @@
       "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "is-my-ip-valid": {
@@ -14724,11 +14724,11 @@
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-nan": {
@@ -14736,7 +14736,7 @@
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
       "integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
       "requires": {
-        "define-properties": "^1.1.1"
+        "define-properties": "1.1.2"
       }
     },
     "is-natural-number": {
@@ -14754,7 +14754,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-obj": {
@@ -14772,7 +14772,7 @@
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -14792,7 +14792,7 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -14800,7 +14800,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -14813,7 +14813,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -14860,7 +14860,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "is-regexp": {
@@ -14874,7 +14874,7 @@
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "requires": {
-        "is-unc-path": "^0.1.1"
+        "is-unc-path": "0.1.2"
       }
     },
     "is-relative-url": {
@@ -14882,7 +14882,7 @@
       "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-2.0.0.tgz",
       "integrity": "sha1-cpAtf+BLPUeS59sV+duEtyBMnO8=",
       "requires": {
-        "is-absolute-url": "^2.0.0"
+        "is-absolute-url": "2.1.0"
       }
     },
     "is-resolvable": {
@@ -14917,7 +14917,7 @@
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "requires": {
-        "html-comment-regex": "^1.1.0"
+        "html-comment-regex": "1.1.1"
       }
     },
     "is-symbol": {
@@ -14941,7 +14941,7 @@
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
       "requires": {
-        "unc-path-regex": "^0.1.0"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-url": {
@@ -14994,7 +14994,7 @@
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
       "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
       "requires": {
-        "punycode": "2.x.x"
+        "punycode": "2.1.0"
       }
     },
     "isexe": {
@@ -15020,8 +15020,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -15034,8 +15034,8 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "items": {
@@ -15053,22 +15053,22 @@
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.28.tgz",
       "integrity": "sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=",
       "requires": {
-        "bignumber.js": "^2.1.0",
+        "bignumber.js": "2.4.0",
         "bmp-js": "0.0.3",
-        "es6-promise": "^3.0.2",
-        "exif-parser": "^0.1.9",
-        "file-type": "^3.1.0",
-        "jpeg-js": "^0.2.0",
-        "load-bmfont": "^1.2.3",
-        "mime": "^1.3.4",
+        "es6-promise": "3.3.1",
+        "exif-parser": "0.1.12",
+        "file-type": "3.9.0",
+        "jpeg-js": "0.2.0",
+        "load-bmfont": "1.3.0",
+        "mime": "1.6.0",
         "mkdirp": "0.5.1",
-        "pixelmatch": "^4.0.0",
-        "pngjs": "^3.0.0",
-        "read-chunk": "^1.0.1",
-        "request": "^2.65.0",
-        "stream-to-buffer": "^0.1.0",
-        "tinycolor2": "^1.1.2",
-        "url-regex": "^3.0.0"
+        "pixelmatch": "4.0.2",
+        "pngjs": "3.3.3",
+        "read-chunk": "1.0.1",
+        "request": "2.85.0",
+        "stream-to-buffer": "0.1.0",
+        "tinycolor2": "1.4.1",
+        "url-regex": "3.2.0"
       },
       "dependencies": {
         "es6-promise": {
@@ -15088,9 +15088,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
       "integrity": "sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==",
       "requires": {
-        "hoek": "4.x.x",
-        "isemail": "3.x.x",
-        "topo": "2.x.x"
+        "hoek": "4.2.1",
+        "isemail": "3.1.2",
+        "topo": "2.0.2"
       }
     },
     "jotted": {
@@ -15123,8 +15123,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
       }
     },
     "js2xmlparser": {
@@ -15150,18 +15150,18 @@
       "integrity": "sha1-tDygPlSldd//REijgl4RxNuPh6E=",
       "dev": true,
       "requires": {
-        "bluebird": "~3.4.6",
-        "catharsis": "~0.8.8",
-        "escape-string-regexp": "~1.0.5",
-        "espree": "~3.1.7",
-        "js2xmlparser": "~1.0.0",
-        "klaw": "~1.3.0",
-        "marked": "~0.3.6",
-        "mkdirp": "~0.5.1",
-        "requizzle": "~0.2.1",
-        "strip-json-comments": "~2.0.1",
+        "bluebird": "3.4.7",
+        "catharsis": "0.8.9",
+        "escape-string-regexp": "1.0.5",
+        "espree": "3.1.7",
+        "js2xmlparser": "1.0.0",
+        "klaw": "1.3.1",
+        "marked": "0.3.19",
+        "mkdirp": "0.5.1",
+        "requizzle": "0.2.1",
+        "strip-json-comments": "2.0.1",
         "taffydb": "2.6.2",
-        "underscore": "~1.8.3"
+        "underscore": "1.8.3"
       },
       "dependencies": {
         "bluebird": {
@@ -15176,8 +15176,8 @@
           "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
           "dev": true,
           "requires": {
-            "acorn": "^3.3.0",
-            "acorn-jsx": "^3.0.0"
+            "acorn": "3.3.0",
+            "acorn-jsx": "3.0.1"
           }
         },
         "underscore": {
@@ -15219,7 +15219,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -15242,7 +15242,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonfilter": {
@@ -15251,10 +15251,10 @@
       "integrity": "sha1-Ie987cdRk4E8dZMulqmL4gW6WhE=",
       "dev": true,
       "requires": {
-        "JSONStream": "^0.8.4",
-        "minimist": "^1.1.0",
-        "stream-combiner": "^0.2.1",
-        "through2": "^0.6.3"
+        "JSONStream": "0.8.4",
+        "minimist": "1.2.0",
+        "stream-combiner": "0.2.2",
+        "through2": "0.6.5"
       },
       "dependencies": {
         "isarray": {
@@ -15269,10 +15269,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -15287,8 +15287,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -15303,7 +15303,7 @@
       "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
       "integrity": "sha1-pltPoPEL2nGaBUQep7lMVfPhW64=",
       "requires": {
-        "debug": "^2.1.3"
+        "debug": "2.6.9"
       }
     },
     "jsonparse": {
@@ -15323,11 +15323,11 @@
       "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-0.7.7.tgz",
       "integrity": "sha512-IuW4Q7gj9Hm/ZSjT7U5PEI1ZS8sfPj2ZOV9+5kEo4iVYVSjfs25wPvNUpq/Mkmdmz3VIe1KWIBwIBv2M+ML1Fw==",
       "requires": {
-        "asn1.js": "^4.9.1",
-        "base64url": "^2.0.0",
-        "elliptic": "^6.3.2",
-        "key-encoder": "^1.1.6",
-        "validator": "^7.0.0"
+        "asn1.js": "4.10.1",
+        "base64url": "2.0.0",
+        "elliptic": "6.4.0",
+        "key-encoder": "1.1.6",
+        "validator": "7.2.0"
       }
     },
     "jspm": {
@@ -15336,27 +15336,27 @@
       "integrity": "sha512-LQE/RbnkX00T6crRORvGumoMm5nLrPFU3nYdEax9KF3KE1L03fyO7bkuOyvF6u7QUg/PttLSrXCM2DOIvTUyoA==",
       "optional": true,
       "requires": {
-        "bluebird": "^3.0.5",
-        "chalk": "^1.1.1",
-        "core-js": "^1.2.6",
-        "glob": "^6.0.1",
-        "graceful-fs": "^4.1.2",
-        "jspm-github": "^0.14.11",
-        "jspm-npm": "^0.30.3",
-        "jspm-registry": "^0.4.1",
-        "liftoff": "^2.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "~0.5.1",
-        "ncp": "^2.0.0",
-        "proper-lockfile": "^1.1.2",
-        "request": "^2.67.0",
-        "rimraf": "^2.4.4",
-        "sane": "^1.3.3",
-        "semver": "^5.1.0",
+        "bluebird": "3.5.1",
+        "chalk": "1.1.3",
+        "core-js": "1.2.7",
+        "glob": "6.0.4",
+        "graceful-fs": "4.1.11",
+        "jspm-github": "0.14.13",
+        "jspm-npm": "0.30.4",
+        "jspm-registry": "0.4.4",
+        "liftoff": "2.5.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "ncp": "2.0.0",
+        "proper-lockfile": "1.2.0",
+        "request": "2.85.0",
+        "rimraf": "2.6.2",
+        "sane": "1.7.0",
+        "semver": "5.5.0",
         "systemjs": "0.21.3",
         "systemjs-builder": "0.16.13",
         "traceur": "0.0.105",
-        "uglify-js": "^2.6.1"
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "core-js": {
@@ -15371,11 +15371,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "optional": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -15383,7 +15383,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -15394,16 +15394,16 @@
       "integrity": "sha1-Mm5SF9NjmyFgkpOwHn4Yd13T3Mc=",
       "optional": true,
       "requires": {
-        "bluebird": "^3.0.5",
-        "expand-tilde": "^1.2.0",
-        "graceful-fs": "^4.1.3",
-        "mkdirp": "^0.5.1",
-        "netrc": "^0.1.3",
-        "request": "^2.74.0",
-        "rimraf": "^2.5.4",
-        "semver": "^5.0.1",
-        "tar-fs": "^1.13.0",
-        "which": "^1.0.9"
+        "bluebird": "3.5.1",
+        "expand-tilde": "1.2.2",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "netrc": "0.1.4",
+        "request": "2.85.0",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "tar-fs": "1.16.2",
+        "which": "1.3.0"
       }
     },
     "jspm-npm": {
@@ -15412,16 +15412,16 @@
       "integrity": "sha512-Gx9/HGtbV4igvvAzhI8rGSzUIUIZtIK5kA7yf+5dGqmbD6hUUK29OxhbF7y/xXmpqyJ7iwiEY5vIszT5rPaz+A==",
       "optional": true,
       "requires": {
-        "bluebird": "^3.0.5",
-        "buffer-peek-stream": "^1.0.1",
-        "graceful-fs": "^4.1.3",
-        "mkdirp": "^0.5.1",
-        "readdirp": "^2.0.0",
-        "request": "^2.58.0",
-        "semver": "^5.0.1",
-        "tar-fs": "^1.13.0",
+        "bluebird": "3.5.1",
+        "buffer-peek-stream": "1.0.1",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "readdirp": "2.1.0",
+        "request": "2.85.0",
+        "semver": "5.5.0",
+        "tar-fs": "1.16.2",
         "traceur": "0.0.105",
-        "which": "^1.1.1"
+        "which": "1.3.0"
       }
     },
     "jspm-registry": {
@@ -15430,10 +15430,10 @@
       "integrity": "sha1-1TFmA1qHzc5YXWK6o5dWhUaZbXA=",
       "optional": true,
       "requires": {
-        "graceful-fs": "^4.1.3",
-        "rimraf": "^2.3.2",
-        "rsvp": "^3.0.18",
-        "semver": "^4.3.3"
+        "graceful-fs": "4.1.11",
+        "rimraf": "2.6.2",
+        "rsvp": "3.6.2",
+        "semver": "4.3.6"
       },
       "dependencies": {
         "semver": {
@@ -15461,8 +15461,8 @@
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.0.0",
-        "promise": "^7.0.1"
+        "is-promise": "2.1.0",
+        "promise": "7.3.1"
       }
     },
     "jsx-ast-utils": {
@@ -15481,9 +15481,9 @@
       "resolved": "https://registry.npmjs.org/key-encoder/-/key-encoder-1.1.6.tgz",
       "integrity": "sha1-ATVYLNPQp+t5LZTso4e2gejloq0=",
       "requires": {
-        "asn1.js": "^2.2.0",
-        "bn.js": "^3.1.2",
-        "elliptic": "^5.1.0"
+        "asn1.js": "2.2.1",
+        "bn.js": "3.3.0",
+        "elliptic": "5.2.1"
       },
       "dependencies": {
         "asn1.js": {
@@ -15491,9 +15491,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
           "integrity": "sha1-yLpN1o6EQxKIEmIwyyBFvfqfv+E=",
           "requires": {
-            "bn.js": "^2.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
+            "bn.js": "2.2.0",
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.1"
           },
           "dependencies": {
             "bn.js": {
@@ -15513,10 +15513,10 @@
           "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
           "integrity": "sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=",
           "requires": {
-            "bn.js": "^3.1.1",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "inherits": "^2.0.1"
+            "bn.js": "3.3.0",
+            "brorand": "1.1.0",
+            "hash.js": "1.1.3",
+            "inherits": "2.0.3"
           }
         }
       }
@@ -15526,7 +15526,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "kjua": {
@@ -15539,7 +15539,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       }
     },
     "known-css-properties": {
@@ -15553,7 +15553,7 @@
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "lazy-cache": {
@@ -15571,7 +15571,7 @@
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.6"
       }
     },
     "lcid": {
@@ -15579,7 +15579,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "ldjson-stream": {
@@ -15588,8 +15588,8 @@
       "integrity": "sha1-kb7O2lrE7SsX5kn7d356v6AYnCs=",
       "dev": true,
       "requires": {
-        "split2": "^0.2.1",
-        "through2": "^0.6.1"
+        "split2": "0.2.1",
+        "through2": "0.6.5"
       },
       "dependencies": {
         "isarray": {
@@ -15604,10 +15604,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -15622,8 +15622,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -15639,8 +15639,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "liftoff": {
@@ -15648,14 +15648,14 @@
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.1",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.7.1"
       }
     },
     "linked-list": {
@@ -15669,12 +15669,12 @@
       "integrity": "sha1-u358cQ3mvK/LE8s7jIHgwBMey8k=",
       "requires": {
         "buffer-equal": "0.0.1",
-        "mime": "^1.3.4",
-        "parse-bmfont-ascii": "^1.0.3",
-        "parse-bmfont-binary": "^1.0.5",
-        "parse-bmfont-xml": "^1.1.0",
-        "xhr": "^2.0.1",
-        "xtend": "^4.0.0"
+        "mime": "1.6.0",
+        "parse-bmfont-ascii": "1.0.6",
+        "parse-bmfont-binary": "1.0.6",
+        "parse-bmfont-xml": "1.1.3",
+        "xhr": "2.4.1",
+        "xtend": "4.0.1"
       }
     },
     "load-json-file": {
@@ -15682,10 +15682,10 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -15701,8 +15701,8 @@
       "integrity": "sha512-FYzamtURIJefQykZGtiClYuZkJBUKzmx8Tc74y8JGAulDzbzVm/C+w/MbAljHRr+REL0cRzy3WgnHE+T8gce5g==",
       "dev": true,
       "requires": {
-        "npm-prefix": "^1.2.0",
-        "resolve-from": "^4.0.0"
+        "npm-prefix": "1.2.0",
+        "resolve-from": "4.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -15718,10 +15718,10 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0",
-        "object-assign": "^4.0.1"
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "locate-path": {
@@ -15729,8 +15729,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -15753,7 +15753,7 @@
       "resolved": "https://registry.npmjs.org/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.5.tgz",
       "integrity": "sha512-QWfEIYxpixOdbd6KBe5g6MDWcyTgP3trDXwKHFqTlXrWiLcs/67fGQ0IWeRyhWlTITQIgMpJAYd2oeIztuV5VA==",
       "requires": {
-        "lodash": "^4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "lodash._basecopy": {
@@ -15777,7 +15777,7 @@
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1"
       }
     },
     "lodash._escapestringchar": {
@@ -15835,8 +15835,8 @@
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1",
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -15845,9 +15845,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -15863,7 +15863,7 @@
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.assign": {
@@ -15901,7 +15901,7 @@
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.escaperegexp": {
@@ -15945,7 +15945,7 @@
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.isplainobject": {
@@ -15963,9 +15963,9 @@
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.map": {
@@ -16033,8 +16033,8 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
-        "lodash.templatesettings": "^4.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
       }
     },
     "lodash.templatesettings": {
@@ -16042,7 +16042,7 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "3.0.0"
       }
     },
     "lodash.toarray": {
@@ -16061,7 +16061,7 @@
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "dev": true,
       "requires": {
-        "lodash.keys": "~2.4.1"
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -16070,9 +16070,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -16082,7 +16082,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "logalot": {
@@ -16090,8 +16090,8 @@
       "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
       "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
       "requires": {
-        "figures": "^1.3.5",
-        "squeak": "^1.0.0"
+        "figures": "1.7.0",
+        "squeak": "1.3.0"
       },
       "dependencies": {
         "figures": {
@@ -16099,8 +16099,8 @@
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         }
       }
@@ -16120,7 +16120,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -16128,8 +16128,8 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowdb": {
@@ -16137,10 +16137,10 @@
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-0.16.2.tgz",
       "integrity": "sha1-oql262bsV3lykZcPPIfNthEm+jo=",
       "requires": {
-        "graceful-fs": "^4.1.3",
-        "is-promise": "^2.1.0",
-        "lodash": "4",
-        "steno": "^0.4.1"
+        "graceful-fs": "4.1.11",
+        "is-promise": "2.1.0",
+        "lodash": "4.17.10",
+        "steno": "0.4.4"
       }
     },
     "lowercase-keys": {
@@ -16153,10 +16153,10 @@
       "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz",
       "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
       "requires": {
-        "get-stdin": "^4.0.1",
-        "indent-string": "^2.1.0",
-        "longest": "^1.0.0",
-        "meow": "^3.3.0"
+        "get-stdin": "4.0.1",
+        "indent-string": "2.1.0",
+        "longest": "1.0.1",
+        "meow": "3.7.0"
       }
     },
     "lru-cache": {
@@ -16164,8 +16164,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "ltcdr": {
@@ -16183,7 +16183,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "make-iterator": {
@@ -16191,7 +16191,7 @@
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -16207,7 +16207,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "optional": true,
       "requires": {
-        "tmpl": "1.0.x"
+        "tmpl": "1.0.4"
       }
     },
     "map-cache": {
@@ -16225,7 +16225,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "mapz": {
@@ -16233,7 +16233,7 @@
       "resolved": "https://registry.npmjs.org/mapz/-/mapz-1.0.2.tgz",
       "integrity": "sha512-NuY43BoHy5K4jVg3/oD+g8ysNwdXY3HB5UankVWoikxT9YMqgCYC77pNRENTm/DfslLxPFEOyJUw9h9isRty6w==",
       "requires": {
-        "x-is-array": "^0.1.0"
+        "x-is-array": "0.1.0"
       }
     },
     "markdown-escapes": {
@@ -16279,9 +16279,9 @@
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.6"
       }
     },
     "md5-file": {
@@ -16289,7 +16289,7 @@
       "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-3.2.3.tgz",
       "integrity": "sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw==",
       "requires": {
-        "buffer-alloc": "^1.1.0"
+        "buffer-alloc": "1.1.0"
       }
     },
     "md5.js": {
@@ -16297,8 +16297,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "mdast-comment-marker": {
@@ -16312,8 +16312,8 @@
       "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
       "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
       "requires": {
-        "unist-util-modify-children": "^1.0.0",
-        "unist-util-visit": "^1.1.0"
+        "unist-util-modify-children": "1.1.2",
+        "unist-util-visit": "1.3.1"
       }
     },
     "mdast-util-definitions": {
@@ -16321,7 +16321,7 @@
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.2.tgz",
       "integrity": "sha512-9NloPSwaB9f1PKcGqaScfqRf6zKOEjTIXVIbPOmgWI/JKxznlgVXC5C+8qgl3AjYg2vJBRgLYfLICaNiac89iA==",
       "requires": {
-        "unist-util-visit": "^1.0.0"
+        "unist-util-visit": "1.3.1"
       }
     },
     "mdast-util-heading-style": {
@@ -16335,17 +16335,17 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-2.5.0.tgz",
       "integrity": "sha1-8IeETSVcdUDzaQbaMLoQbA7l7i8=",
       "requires": {
-        "collapse-white-space": "^1.0.0",
-        "detab": "^2.0.0",
-        "mdast-util-definitions": "^1.2.0",
-        "mdurl": "^1.0.1",
+        "collapse-white-space": "1.0.4",
+        "detab": "2.0.1",
+        "mdast-util-definitions": "1.2.2",
+        "mdurl": "1.0.1",
         "trim": "0.0.1",
-        "trim-lines": "^1.0.0",
-        "unist-builder": "^1.0.1",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.0",
-        "xtend": "^4.0.1"
+        "trim-lines": "1.1.1",
+        "unist-builder": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.3.1",
+        "xtend": "4.0.1"
       }
     },
     "mdast-util-to-nlcst": {
@@ -16353,10 +16353,10 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-nlcst/-/mdast-util-to-nlcst-3.2.0.tgz",
       "integrity": "sha1-2tJihXZY0eq0tYFKIOL5PXyh47Y=",
       "requires": {
-        "nlcst-to-string": "^2.0.0",
-        "repeat-string": "^1.5.2",
-        "unist-util-position": "^3.0.0",
-        "vfile-location": "^2.0.0"
+        "nlcst-to-string": "2.0.2",
+        "repeat-string": "1.6.1",
+        "unist-util-position": "3.0.1",
+        "vfile-location": "2.0.3"
       }
     },
     "mdast-util-to-string": {
@@ -16369,9 +16369,9 @@
       "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-2.0.1.tgz",
       "integrity": "sha1-sdLLI7+wH4Evp7Vb/+iwqL7fbyE=",
       "requires": {
-        "github-slugger": "^1.1.1",
-        "mdast-util-to-string": "^1.0.2",
-        "unist-util-visit": "^1.1.0"
+        "github-slugger": "1.2.0",
+        "mdast-util-to-string": "1.0.4",
+        "unist-util-visit": "1.3.1"
       }
     },
     "mdurl": {
@@ -16389,7 +16389,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memory-fs": {
@@ -16397,8 +16397,8 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
       "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.6"
       }
     },
     "meow": {
@@ -16406,16 +16406,16 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "load-json-file": {
@@ -16423,11 +16423,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "path-type": {
@@ -16435,9 +16435,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -16450,9 +16450,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -16460,8 +16460,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "strip-bom": {
@@ -16469,7 +16469,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -16489,7 +16489,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "methods": {
@@ -16513,7 +16513,7 @@
       "resolved": "https://registry.npmjs.org/micro-compress/-/micro-compress-1.0.0.tgz",
       "integrity": "sha1-U/WoC0rQMgyhZaVZtuPfFF1PcE8=",
       "requires": {
-        "compression": "^1.6.2"
+        "compression": "1.7.2"
       }
     },
     "micromatch": {
@@ -16521,19 +16521,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "miller-rabin": {
@@ -16541,8 +16541,8 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime": {
@@ -16560,7 +16560,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
@@ -16578,7 +16578,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "^0.1.0"
+        "dom-walk": "0.1.1"
       }
     },
     "mini-svg-data-uri": {
@@ -16602,7 +16602,7 @@
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.0.0"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -16616,8 +16616,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
       }
     },
     "minipass": {
@@ -16625,8 +16625,8 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.0.tgz",
       "integrity": "sha512-jWC2Eg+Np4bxah7llu1IrUNSJQxtLz/J+pOjTM0nFpJXGAaV18XBWhUn031Q1tAA/TJtA1jgwnOe9S2PQa4Lbg==",
       "requires": {
-        "safe-buffer": "^5.1.1",
-        "yallist": "^3.0.0"
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       },
       "dependencies": {
         "yallist": {
@@ -16641,7 +16641,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
       "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.0"
       }
     },
     "mitt": {
@@ -16654,8 +16654,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -16663,7 +16663,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -16688,9 +16688,9 @@
       "resolved": "https://registry.npmjs.org/mnid/-/mnid-0.1.1.tgz",
       "integrity": "sha1-TjiZtHbwLaKfcbUMevU4Dccrh5o=",
       "requires": {
-        "base-x": "^3.0.0",
-        "buffer": "^5.0.5",
-        "js-sha3": "^0.5.7"
+        "base-x": "3.0.4",
+        "buffer": "5.1.0",
+        "js-sha3": "0.5.7"
       },
       "dependencies": {
         "buffer": {
@@ -16698,8 +16698,8 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
           "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "1.3.0",
+            "ieee754": "1.1.11"
           }
         }
       }
@@ -16730,9 +16730,9 @@
       "integrity": "sha1-xa2kJTV7dEulSELr3OHI8L5UK28=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "minimatch": "^2.0.1"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "minimatch": "2.0.10"
       }
     },
     "multipipe": {
@@ -16748,7 +16748,7 @@
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
           "requires": {
-            "readable-stream": "~1.1.9"
+            "readable-stream": "1.1.14"
           }
         },
         "isarray": {
@@ -16761,10 +16761,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -16789,18 +16789,18 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -16854,8 +16854,8 @@
       "resolved": "https://registry.npmjs.org/nets/-/nets-3.2.0.tgz",
       "integrity": "sha1-1RH7q3rxHaAT8huX7pF0fTOFLTg=",
       "requires": {
-        "request": "^2.65.0",
-        "xhr": "^2.1.0"
+        "request": "2.85.0",
+        "xhr": "2.4.1"
       }
     },
     "next-tick": {
@@ -16879,7 +16879,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.1.tgz",
       "integrity": "sha512-pUlswqpHQ7zGPI9lGjZ4XDNIEUDbHxsltfIRb7dTnYdhgHWHOcB0MLZKLoCz6UMcGzSPG5wGl1HODZVQAUsH6w==",
       "requires": {
-        "semver": "^5.4.1"
+        "semver": "5.5.0"
       }
     },
     "node-emoji": {
@@ -16887,7 +16887,7 @@
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
       "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
       "requires": {
-        "lodash.toarray": "^4.4.0"
+        "lodash.toarray": "4.4.0"
       }
     },
     "node-eta": {
@@ -16900,8 +16900,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-int64": {
@@ -16914,28 +16914,28 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^1.0.0",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
+        "assert": "1.4.1",
+        "browserify-zlib": "0.2.0",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "domain-browser": "1.2.0",
+        "events": "1.1.1",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.0",
-        "process": "^0.11.10",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.3.3",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.7.2",
-        "string_decoder": "^1.0.0",
-        "timers-browserify": "^2.0.4",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.6",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.8.2",
+        "string_decoder": "1.1.1",
+        "timers-browserify": "2.0.10",
         "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.10.3",
+        "url": "0.11.0",
+        "util": "0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -16961,8 +16961,8 @@
       "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
       "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "~1.0.31"
+        "inherits": "2.0.3",
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "isarray": {
@@ -16975,10 +16975,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -16998,10 +16998,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -17009,7 +17009,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
@@ -17028,10 +17028,10 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "prepend-http": "^1.0.0",
-        "query-string": "^4.1.0",
-        "sort-keys": "^1.0.0"
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
       }
     },
     "npm": {
@@ -17039,133 +17039,133 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-6.0.1.tgz",
       "integrity": "sha512-N3uW8jeIXIBp5G3Q6Yu3TTN1ss6BUWuDTHk2JkdTUGaUf0AwKdtVs63O5B75C9NNn7y/7tMpkMCE++xpRhjUBw==",
       "requires": {
-        "JSONStream": "^1.3.2",
-        "abbrev": "~1.1.1",
-        "ansi-regex": "~3.0.0",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "aproba": "~1.2.0",
-        "archy": "~1.0.0",
-        "bin-links": "^1.1.2",
-        "bluebird": "~3.5.1",
-        "byte-size": "^4.0.2",
-        "cacache": "^11.0.1",
-        "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
-        "cli-columns": "^3.1.2",
-        "cli-table2": "~0.2.0",
-        "cmd-shim": "~2.0.2",
-        "columnify": "~1.5.4",
-        "config-chain": "~1.1.11",
-        "debuglog": "*",
-        "detect-indent": "~5.0.0",
-        "detect-newline": "^2.1.0",
-        "dezalgo": "~1.0.3",
-        "editor": "~1.0.0",
-        "figgy-pudding": "^3.1.0",
-        "find-npm-prefix": "^1.0.2",
-        "fs-vacuum": "~1.2.10",
-        "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
-        "glob": "~7.1.2",
-        "graceful-fs": "~4.1.11",
-        "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.6.0",
-        "iferr": "^1.0.0",
-        "imurmurhash": "*",
-        "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
-        "ini": "^1.3.5",
-        "init-package-json": "^1.10.3",
-        "is-cidr": "^2.0.5",
-        "json-parse-better-errors": "^1.0.2",
-        "lazy-property": "~1.0.0",
-        "libcipm": "^1.6.2",
-        "libnpmhook": "^4.0.1",
-        "libnpx": "^10.2.0",
-        "lock-verify": "^2.0.2",
-        "lockfile": "^1.0.4",
-        "lodash._baseindexof": "*",
-        "lodash._baseuniq": "~4.6.0",
-        "lodash._bindcallback": "*",
-        "lodash._cacheindexof": "*",
-        "lodash._createcache": "*",
-        "lodash._getnative": "*",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.restparam": "*",
-        "lodash.union": "~4.6.0",
-        "lodash.uniq": "~4.5.0",
-        "lodash.without": "~4.4.0",
-        "lru-cache": "^4.1.2",
-        "meant": "~1.0.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "~0.5.1",
-        "move-concurrently": "^1.0.1",
-        "node-gyp": "^3.6.2",
-        "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-audit-report": "^1.0.8",
-        "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^2.0.1",
-        "npm-package-arg": "^6.1.0",
-        "npm-packlist": "~1.1.10",
-        "npm-pick-manifest": "^2.1.0",
-        "npm-profile": "^3.0.1",
-        "npm-registry-client": "^8.5.1",
-        "npm-registry-fetch": "^1.1.0",
-        "npm-user-validate": "~1.0.0",
-        "npmlog": "~4.1.2",
-        "once": "~1.4.0",
-        "opener": "~1.4.3",
-        "osenv": "^0.1.5",
-        "pacote": "^8.1.1",
-        "path-is-inside": "~1.0.2",
-        "promise-inflight": "~1.0.1",
-        "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.1.0",
-        "qw": "~1.0.1",
-        "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
-        "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
-        "read-package-tree": "^5.2.1",
-        "readable-stream": "^2.3.6",
-        "readdir-scoped-modules": "*",
-        "request": "^2.85.0",
-        "retry": "^0.12.0",
-        "rimraf": "~2.6.2",
-        "safe-buffer": "^5.1.2",
-        "semver": "^5.5.0",
-        "sha": "~2.0.1",
-        "slide": "~1.1.6",
-        "sorted-object": "~2.0.1",
-        "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.0",
-        "strip-ansi": "~4.0.0",
-        "tar": "^4.4.2",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
+        "JSONStream": "1.3.2",
+        "abbrev": "1.1.1",
+        "ansi-regex": "3.0.0",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.2.0",
+        "archy": "1.0.0",
+        "bin-links": "1.1.2",
+        "bluebird": "3.5.1",
+        "byte-size": "4.0.2",
+        "cacache": "11.0.1",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "cli-columns": "3.1.2",
+        "cli-table2": "0.2.0",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "detect-newline": "2.1.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "figgy-pudding": "3.1.0",
+        "find-npm-prefix": "1.0.2",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.6.0",
+        "iferr": "1.0.0",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.5",
+        "init-package-json": "1.10.3",
+        "is-cidr": "2.0.5",
+        "json-parse-better-errors": "1.0.2",
+        "lazy-property": "1.0.0",
+        "libcipm": "1.6.2",
+        "libnpmhook": "4.0.1",
+        "libnpx": "10.2.0",
+        "lock-verify": "2.0.2",
+        "lockfile": "1.0.4",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.2",
+        "meant": "1.0.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "node-gyp": "3.6.2",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-audit-report": "1.0.8",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-lifecycle": "2.0.1",
+        "npm-package-arg": "6.1.0",
+        "npm-packlist": "1.1.10",
+        "npm-pick-manifest": "2.1.0",
+        "npm-profile": "3.0.1",
+        "npm-registry-client": "8.5.1",
+        "npm-registry-fetch": "1.1.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.4.3",
+        "osenv": "0.1.5",
+        "pacote": "8.1.1",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.12.0",
+        "query-string": "6.1.0",
+        "qw": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.13",
+        "read-package-tree": "5.2.1",
+        "readable-stream": "2.3.6",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.85.0",
+        "retry": "0.12.0",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.2",
+        "semver": "5.5.0",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "6.0.0",
+        "strip-ansi": "4.0.0",
+        "tar": "4.4.2",
+        "text-table": "0.2.0",
+        "tiny-relative-date": "1.3.0",
         "uid-number": "0.0.6",
-        "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
-        "unpipe": "~1.0.0",
-        "update-notifier": "^2.5.0",
-        "uuid": "^3.2.1",
-        "validate-npm-package-license": "^3.0.3",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "~1.3.0",
-        "worker-farm": "^1.6.0",
-        "wrappy": "~1.0.2",
-        "write-file-atomic": "^2.3.0"
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.5.0",
+        "uuid": "3.2.1",
+        "validate-npm-package-license": "3.0.3",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.3.0",
+        "worker-farm": "1.6.0",
+        "wrappy": "1.0.2",
+        "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "JSONStream": {
           "version": "1.3.2",
           "bundled": true,
           "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
           },
           "dependencies": {
             "jsonparse": {
@@ -17206,11 +17206,11 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
-            "write-file-atomic": "^2.3.0"
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "write-file-atomic": "2.3.0"
           }
         },
         "bluebird": {
@@ -17225,20 +17225,20 @@
           "version": "11.0.1",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "figgy-pudding": "^3.1.0",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.2",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^6.0.0",
-            "unique-filename": "^1.1.0",
-            "y18n": "^4.0.0"
+            "bluebird": "3.5.1",
+            "chownr": "1.0.1",
+            "figgy-pudding": "3.1.0",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.2",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "6.0.0",
+            "unique-filename": "1.1.0",
+            "y18n": "4.0.0"
           },
           "dependencies": {
             "y18n": {
@@ -17259,16 +17259,16 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.1"
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
             "string-width": {
               "version": "2.1.1",
               "bundled": true,
               "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
               },
               "dependencies": {
                 "is-fullwidth-code-point": {
@@ -17279,7 +17279,7 @@
                   "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "^3.0.0"
+                    "ansi-regex": "3.0.0"
                   }
                 }
               }
@@ -17288,7 +17288,7 @@
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -17303,9 +17303,9 @@
           "version": "0.2.0",
           "bundled": true,
           "requires": {
-            "colors": "^1.1.2",
-            "lodash": "^3.10.1",
-            "string-width": "^1.0.1"
+            "colors": "1.1.2",
+            "lodash": "3.10.1",
+            "string-width": "1.0.2"
           },
           "dependencies": {
             "colors": {
@@ -17321,9 +17321,9 @@
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               },
               "dependencies": {
                 "code-point-at": {
@@ -17334,7 +17334,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "number-is-nan": "^1.0.0"
+                    "number-is-nan": "1.0.1"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -17347,7 +17347,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -17364,23 +17364,23 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "~0.5.0"
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
           }
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
           "requires": {
-            "strip-ansi": "^3.0.0",
-            "wcwidth": "^1.0.0"
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
           },
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -17393,14 +17393,14 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "defaults": "^1.0.3"
+                "defaults": "1.0.3"
               },
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "clone": "^1.0.2"
+                    "clone": "1.0.2"
                   },
                   "dependencies": {
                     "clone": {
@@ -17417,8 +17417,8 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ini": "^1.3.4",
-            "proto-list": "~1.2.1"
+            "ini": "1.3.5",
+            "proto-list": "1.2.4"
           },
           "dependencies": {
             "proto-list": {
@@ -17443,8 +17443,8 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "asap": "^2.0.0",
-            "wrappy": "1"
+            "asap": "2.0.5",
+            "wrappy": "1.0.2"
           },
           "dependencies": {
             "asap": {
@@ -17469,19 +17469,19 @@
           "version": "1.2.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "path-is-inside": "^1.0.1",
-            "rimraf": "^2.5.2"
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.2"
           }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.6"
           },
           "dependencies": {
             "iferr": {
@@ -17494,14 +17494,14 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "fs-vacuum": "^1.2.10",
-            "graceful-fs": "^4.1.11",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "path-is-inside": "^1.0.2",
-            "read-cmd-shim": "^1.0.1",
-            "slide": "^1.1.6"
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
           },
           "dependencies": {
             "iferr": {
@@ -17514,12 +17514,12 @@
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           },
           "dependencies": {
             "fs.realpath": {
@@ -17530,14 +17530,14 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "^1.0.0",
+                    "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -17583,8 +17583,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -17599,21 +17599,21 @@
           "version": "1.10.3",
           "bundled": true,
           "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-            "promzard": "^0.3.0",
-            "read": "~1.0.1",
-            "read-package-json": "1 || 2",
-            "semver": "2.x || 3.x || 4 || 5",
-            "validate-npm-package-license": "^3.0.1",
-            "validate-npm-package-name": "^3.0.0"
+            "glob": "7.1.2",
+            "npm-package-arg": "6.1.0",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.13",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3",
+            "validate-npm-package-name": "3.0.0"
           },
           "dependencies": {
             "promzard": {
               "version": "0.3.0",
               "bundled": true,
               "requires": {
-                "read": "1"
+                "read": "1.0.7"
               }
             }
           }
@@ -17622,14 +17622,14 @@
           "version": "2.0.5",
           "bundled": true,
           "requires": {
-            "cidr-regex": "^2.0.8"
+            "cidr-regex": "2.0.8"
           },
           "dependencies": {
             "cidr-regex": {
               "version": "2.0.8",
               "bundled": true,
               "requires": {
-                "ip-regex": "^2.1.0"
+                "ip-regex": "2.1.0"
               },
               "dependencies": {
                 "ip-regex": {
@@ -17652,19 +17652,19 @@
           "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "bin-links": "^1.1.0",
-            "bluebird": "^3.5.1",
-            "find-npm-prefix": "^1.0.2",
-            "graceful-fs": "^4.1.11",
-            "lock-verify": "^2.0.0",
-            "npm-lifecycle": "^2.0.0",
-            "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.0.0",
-            "pacote": "^7.5.1",
-            "protoduck": "^5.0.0",
-            "read-package-json": "^2.0.12",
-            "rimraf": "^2.6.2",
-            "worker-farm": "^1.5.4"
+            "bin-links": "1.1.2",
+            "bluebird": "3.5.1",
+            "find-npm-prefix": "1.0.2",
+            "graceful-fs": "4.1.11",
+            "lock-verify": "2.0.2",
+            "npm-lifecycle": "2.0.1",
+            "npm-logical-tree": "1.2.1",
+            "npm-package-arg": "6.1.0",
+            "pacote": "7.6.1",
+            "protoduck": "5.0.0",
+            "read-package-json": "2.0.13",
+            "rimraf": "2.6.2",
+            "worker-farm": "1.6.0"
           },
           "dependencies": {
             "npm-logical-tree": {
@@ -17675,75 +17675,75 @@
               "version": "7.6.1",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "cacache": "^10.0.4",
-                "get-stream": "^3.0.0",
-                "glob": "^7.1.2",
-                "lru-cache": "^4.1.1",
-                "make-fetch-happen": "^2.6.0",
-                "minimatch": "^3.0.4",
-                "mississippi": "^3.0.0",
-                "mkdirp": "^0.5.1",
-                "normalize-package-data": "^2.4.0",
-                "npm-package-arg": "^6.0.0",
-                "npm-packlist": "^1.1.10",
-                "npm-pick-manifest": "^2.1.0",
-                "osenv": "^0.1.5",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^1.1.1",
-                "protoduck": "^5.0.0",
-                "rimraf": "^2.6.2",
-                "safe-buffer": "^5.1.1",
-                "semver": "^5.5.0",
-                "ssri": "^5.2.4",
-                "tar": "^4.4.0",
-                "unique-filename": "^1.1.0",
-                "which": "^1.3.0"
+                "bluebird": "3.5.1",
+                "cacache": "10.0.4",
+                "get-stream": "3.0.0",
+                "glob": "7.1.2",
+                "lru-cache": "4.1.2",
+                "make-fetch-happen": "2.6.0",
+                "minimatch": "3.0.4",
+                "mississippi": "3.0.0",
+                "mkdirp": "0.5.1",
+                "normalize-package-data": "2.4.0",
+                "npm-package-arg": "6.1.0",
+                "npm-packlist": "1.1.10",
+                "npm-pick-manifest": "2.1.0",
+                "osenv": "0.1.5",
+                "promise-inflight": "1.0.1",
+                "promise-retry": "1.1.1",
+                "protoduck": "5.0.0",
+                "rimraf": "2.6.2",
+                "safe-buffer": "5.1.2",
+                "semver": "5.5.0",
+                "ssri": "5.3.0",
+                "tar": "4.4.2",
+                "unique-filename": "1.1.0",
+                "which": "1.3.0"
               },
               "dependencies": {
                 "cacache": {
                   "version": "10.0.4",
                   "bundled": true,
                   "requires": {
-                    "bluebird": "^3.5.1",
-                    "chownr": "^1.0.1",
-                    "glob": "^7.1.2",
-                    "graceful-fs": "^4.1.11",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^2.0.0",
-                    "mkdirp": "^0.5.1",
-                    "move-concurrently": "^1.0.1",
-                    "promise-inflight": "^1.0.1",
-                    "rimraf": "^2.6.2",
-                    "ssri": "^5.2.4",
-                    "unique-filename": "^1.1.0",
-                    "y18n": "^4.0.0"
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.2",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
                   },
                   "dependencies": {
                     "mississippi": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^2.0.1",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
                       },
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.6.2",
                           "bundled": true,
                           "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
                           },
                           "dependencies": {
                             "buffer-from": {
@@ -17760,10 +17760,10 @@
                           "version": "3.5.4",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -17776,32 +17776,32 @@
                           "version": "1.4.1",
                           "bundled": true,
                           "requires": {
-                            "once": "^1.4.0"
+                            "once": "1.4.0"
                           }
                         },
                         "flush-write-stream": {
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           }
                         },
                         "from2": {
                           "version": "2.3.0",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           }
                         },
                         "parallel-transform": {
                           "version": "1.1.0",
                           "bundled": true,
                           "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           },
                           "dependencies": {
                             "cyclist": {
@@ -17814,25 +17814,25 @@
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
                           }
                         },
                         "pumpify": {
                           "version": "1.4.0",
                           "bundled": true,
                           "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
                           }
                         },
                         "stream-each": {
                           "version": "1.2.2",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -17845,8 +17845,8 @@
                           "version": "2.0.3",
                           "bundled": true,
                           "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
                           },
                           "dependencies": {
                             "xtend": {
@@ -17871,31 +17871,31 @@
                   "version": "2.6.0",
                   "bundled": true,
                   "requires": {
-                    "agentkeepalive": "^3.3.0",
-                    "cacache": "^10.0.0",
-                    "http-cache-semantics": "^3.8.0",
-                    "http-proxy-agent": "^2.0.0",
-                    "https-proxy-agent": "^2.1.0",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^1.2.0",
-                    "node-fetch-npm": "^2.0.2",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^3.0.1",
-                    "ssri": "^5.0.0"
+                    "agentkeepalive": "3.4.1",
+                    "cacache": "10.0.4",
+                    "http-cache-semantics": "3.8.1",
+                    "http-proxy-agent": "2.1.0",
+                    "https-proxy-agent": "2.2.1",
+                    "lru-cache": "4.1.2",
+                    "mississippi": "1.3.1",
+                    "node-fetch-npm": "2.0.2",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "3.0.1",
+                    "ssri": "5.3.0"
                   },
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.4.1",
                       "bundled": true,
                       "requires": {
-                        "humanize-ms": "^1.2.1"
+                        "humanize-ms": "1.2.1"
                       },
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
                           "bundled": true,
                           "requires": {
-                            "ms": "^2.0.0"
+                            "ms": "2.1.1"
                           },
                           "dependencies": {
                             "ms": {
@@ -17914,7 +17914,7 @@
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "4",
+                        "agent-base": "4.2.0",
                         "debug": "3.1.0"
                       },
                       "dependencies": {
@@ -17922,14 +17922,14 @@
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -17959,22 +17959,22 @@
                       "version": "2.2.1",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^3.1.0"
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -18004,26 +18004,26 @@
                       "version": "1.3.1",
                       "bundled": true,
                       "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^1.0.0",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "1.0.3",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
                       },
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.6.2",
                           "bundled": true,
                           "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
                           },
                           "dependencies": {
                             "buffer-from": {
@@ -18040,10 +18040,10 @@
                           "version": "3.5.4",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -18056,32 +18056,32 @@
                           "version": "1.4.1",
                           "bundled": true,
                           "requires": {
-                            "once": "^1.4.0"
+                            "once": "1.4.0"
                           }
                         },
                         "flush-write-stream": {
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           }
                         },
                         "from2": {
                           "version": "2.3.0",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           }
                         },
                         "parallel-transform": {
                           "version": "1.1.0",
                           "bundled": true,
                           "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           },
                           "dependencies": {
                             "cyclist": {
@@ -18094,25 +18094,25 @@
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
                           }
                         },
                         "pumpify": {
                           "version": "1.4.0",
                           "bundled": true,
                           "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
                           },
                           "dependencies": {
                             "pump": {
                               "version": "2.0.1",
                               "bundled": true,
                               "requires": {
-                                "end-of-stream": "^1.1.0",
-                                "once": "^1.3.1"
+                                "end-of-stream": "1.4.1",
+                                "once": "1.4.0"
                               }
                             }
                           }
@@ -18121,8 +18121,8 @@
                           "version": "1.2.2",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -18135,8 +18135,8 @@
                           "version": "2.0.3",
                           "bundled": true,
                           "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
                           },
                           "dependencies": {
                             "xtend": {
@@ -18151,23 +18151,23 @@
                       "version": "2.0.2",
                       "bundled": true,
                       "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-better-errors": "^1.0.0",
-                        "safe-buffer": "^5.1.1"
+                        "encoding": "0.1.12",
+                        "json-parse-better-errors": "1.0.2",
+                        "safe-buffer": "5.1.2"
                       },
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
                           "bundled": true,
                           "requires": {
-                            "iconv-lite": "~0.4.13"
+                            "iconv-lite": "0.4.21"
                           },
                           "dependencies": {
                             "iconv-lite": {
                               "version": "0.4.21",
                               "bundled": true,
                               "requires": {
-                                "safer-buffer": "^2.1.0"
+                                "safer-buffer": "2.1.2"
                               },
                               "dependencies": {
                                 "safer-buffer": {
@@ -18184,22 +18184,22 @@
                       "version": "3.0.1",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "^4.1.0",
-                        "socks": "^1.1.10"
+                        "agent-base": "4.2.0",
+                        "socks": "1.1.10"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -18214,8 +18214,8 @@
                           "version": "1.1.10",
                           "bundled": true,
                           "requires": {
-                            "ip": "^1.1.4",
-                            "smart-buffer": "^1.0.13"
+                            "ip": "1.1.5",
+                            "smart-buffer": "1.1.15"
                           },
                           "dependencies": {
                             "ip": {
@@ -18236,14 +18236,14 @@
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "^1.1.7"
+                    "brace-expansion": "1.1.11"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.11",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -18263,8 +18263,8 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
                   },
                   "dependencies": {
                     "err-code": {
@@ -18281,7 +18281,7 @@
                   "version": "5.3.0",
                   "bundled": true,
                   "requires": {
-                    "safe-buffer": "^5.1.1"
+                    "safe-buffer": "5.1.2"
                   }
                 }
               }
@@ -18290,7 +18290,7 @@
               "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "genfun": "^4.0.1"
+                "genfun": "4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -18305,50 +18305,50 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "^3.1.0",
-            "npm-registry-fetch": "^3.0.0"
+            "figgy-pudding": "3.1.0",
+            "npm-registry-fetch": "3.1.1"
           },
           "dependencies": {
             "npm-registry-fetch": {
               "version": "3.1.1",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^3.1.0",
-                "lru-cache": "^4.1.2",
-                "make-fetch-happen": "^4.0.0",
-                "npm-package-arg": "^6.0.0"
+                "bluebird": "3.5.1",
+                "figgy-pudding": "3.1.0",
+                "lru-cache": "4.1.2",
+                "make-fetch-happen": "4.0.1",
+                "npm-package-arg": "6.1.0"
               },
               "dependencies": {
                 "make-fetch-happen": {
                   "version": "4.0.1",
                   "bundled": true,
                   "requires": {
-                    "agentkeepalive": "^3.4.1",
-                    "cacache": "^11.0.1",
-                    "http-cache-semantics": "^3.8.1",
-                    "http-proxy-agent": "^2.1.0",
-                    "https-proxy-agent": "^2.2.1",
-                    "lru-cache": "^4.1.2",
-                    "mississippi": "^3.0.0",
-                    "node-fetch-npm": "^2.0.2",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^4.0.0",
-                    "ssri": "^6.0.0"
+                    "agentkeepalive": "3.4.1",
+                    "cacache": "11.0.1",
+                    "http-cache-semantics": "3.8.1",
+                    "http-proxy-agent": "2.1.0",
+                    "https-proxy-agent": "2.2.1",
+                    "lru-cache": "4.1.2",
+                    "mississippi": "3.0.0",
+                    "node-fetch-npm": "2.0.2",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "4.0.0",
+                    "ssri": "6.0.0"
                   },
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.4.1",
                       "bundled": true,
                       "requires": {
-                        "humanize-ms": "^1.2.1"
+                        "humanize-ms": "1.2.1"
                       },
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
                           "bundled": true,
                           "requires": {
-                            "ms": "^2.0.0"
+                            "ms": "2.1.1"
                           },
                           "dependencies": {
                             "ms": {
@@ -18367,7 +18367,7 @@
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "4",
+                        "agent-base": "4.2.0",
                         "debug": "3.1.0"
                       },
                       "dependencies": {
@@ -18375,14 +18375,14 @@
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -18412,22 +18412,22 @@
                       "version": "2.2.1",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^3.1.0"
+                        "agent-base": "4.2.0",
+                        "debug": "3.1.0"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -18457,23 +18457,23 @@
                       "version": "2.0.2",
                       "bundled": true,
                       "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-better-errors": "^1.0.0",
-                        "safe-buffer": "^5.1.1"
+                        "encoding": "0.1.12",
+                        "json-parse-better-errors": "1.0.2",
+                        "safe-buffer": "5.1.2"
                       },
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
                           "bundled": true,
                           "requires": {
-                            "iconv-lite": "~0.4.13"
+                            "iconv-lite": "0.4.21"
                           },
                           "dependencies": {
                             "iconv-lite": {
                               "version": "0.4.21",
                               "bundled": true,
                               "requires": {
-                                "safer-buffer": "^2.1.0"
+                                "safer-buffer": "2.1.2"
                               },
                               "dependencies": {
                                 "safer-buffer": {
@@ -18490,8 +18490,8 @@
                       "version": "1.1.1",
                       "bundled": true,
                       "requires": {
-                        "err-code": "^1.0.0",
-                        "retry": "^0.10.0"
+                        "err-code": "1.1.2",
+                        "retry": "0.10.1"
                       },
                       "dependencies": {
                         "err-code": {
@@ -18508,22 +18508,22 @@
                       "version": "4.0.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "~4.1.0",
-                        "socks": "~2.1.6"
+                        "agent-base": "4.1.2",
+                        "socks": "2.1.6"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.2",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.2.4"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -18538,8 +18538,8 @@
                           "version": "2.1.6",
                           "bundled": true,
                           "requires": {
-                            "ip": "^1.1.5",
-                            "smart-buffer": "^4.0.1"
+                            "ip": "1.1.5",
+                            "smart-buffer": "4.0.1"
                           },
                           "dependencies": {
                             "ip": {
@@ -18564,14 +18564,14 @@
           "version": "10.2.0",
           "bundled": true,
           "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.1.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "update-notifier": "2.5.0",
+            "which": "1.3.0",
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
           },
           "dependencies": {
             "dotenv": {
@@ -18586,44 +18586,44 @@
               "version": "11.0.0",
               "bundled": true,
               "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
+                "cliui": "4.0.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "9.0.2"
               },
               "dependencies": {
                 "cliui": {
                   "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "^2.1.1",
-                    "strip-ansi": "^4.0.0",
-                    "wrap-ansi": "^2.0.0"
+                    "string-width": "2.1.1",
+                    "strip-ansi": "4.0.0",
+                    "wrap-ansi": "2.1.0"
                   },
                   "dependencies": {
                     "wrap-ansi": {
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
                       },
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
                           "bundled": true,
                           "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
                           },
                           "dependencies": {
                             "code-point-at": {
@@ -18634,7 +18634,7 @@
                               "version": "1.0.0",
                               "bundled": true,
                               "requires": {
-                                "number-is-nan": "^1.0.0"
+                                "number-is-nan": "1.0.1"
                               },
                               "dependencies": {
                                 "number-is-nan": {
@@ -18649,7 +18649,7 @@
                           "version": "3.0.1",
                           "bundled": true,
                           "requires": {
-                            "ansi-regex": "^2.0.0"
+                            "ansi-regex": "2.1.1"
                           },
                           "dependencies": {
                             "ansi-regex": {
@@ -18670,29 +18670,29 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "locate-path": "^2.0.0"
+                    "locate-path": "2.0.0"
                   },
                   "dependencies": {
                     "locate-path": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
                       },
                       "dependencies": {
                         "p-locate": {
                           "version": "2.0.0",
                           "bundled": true,
                           "requires": {
-                            "p-limit": "^1.1.0"
+                            "p-limit": "1.2.0"
                           },
                           "dependencies": {
                             "p-limit": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "p-try": "^1.0.0"
+                                "p-try": "1.0.0"
                               },
                               "dependencies": {
                                 "p-try": {
@@ -18719,38 +18719,38 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "^0.7.0",
-                    "lcid": "^1.0.0",
-                    "mem": "^1.1.0"
+                    "execa": "0.7.0",
+                    "lcid": "1.0.0",
+                    "mem": "1.1.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "^4.0.1",
-                            "shebang-command": "^1.2.0",
-                            "which": "^1.2.9"
+                            "lru-cache": "4.1.2",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
                           },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "shebang-regex": "^1.0.0"
+                                "shebang-regex": "1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -18773,7 +18773,7 @@
                           "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "^2.0.0"
+                            "path-key": "2.0.1"
                           },
                           "dependencies": {
                             "path-key": {
@@ -18800,7 +18800,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "invert-kv": "^1.0.0"
+                        "invert-kv": "1.0.0"
                       },
                       "dependencies": {
                         "invert-kv": {
@@ -18813,7 +18813,7 @@
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "mimic-fn": "^1.0.0"
+                        "mimic-fn": "1.2.0"
                       },
                       "dependencies": {
                         "mimic-fn": {
@@ -18840,8 +18840,8 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "is-fullwidth-code-point": "^2.0.0",
-                    "strip-ansi": "^4.0.0"
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -18862,7 +18862,7 @@
                   "version": "9.0.2",
                   "bundled": true,
                   "requires": {
-                    "camelcase": "^4.1.0"
+                    "camelcase": "4.1.0"
                   },
                   "dependencies": {
                     "camelcase": {
@@ -18879,15 +18879,15 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^5.1.2 || 6",
-            "semver": "^5.4.1"
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
           }
         },
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
           "requires": {
-            "signal-exit": "^3.0.2"
+            "signal-exit": "3.0.2"
           },
           "dependencies": {
             "signal-exit": {
@@ -18904,8 +18904,8 @@
           "version": "4.6.0",
           "bundled": true,
           "requires": {
-            "lodash._createset": "~4.0.0",
-            "lodash._root": "~3.0.0"
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
           },
           "dependencies": {
             "lodash._createset": {
@@ -18930,7 +18930,7 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "lodash._getnative": "^3.0.0"
+            "lodash._getnative": "3.9.1"
           }
         },
         "lodash._getnative": {
@@ -18961,8 +18961,8 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           },
           "dependencies": {
             "pseudomap": {
@@ -18983,25 +18983,25 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
+            "concat-stream": "1.6.1",
+            "duplexify": "3.5.4",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.2",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "3.0.0",
+            "pumpify": "1.4.0",
+            "stream-each": "1.2.2",
+            "through2": "2.0.3"
           },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
               "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -19014,10 +19014,10 @@
               "version": "3.5.4",
               "bundled": true,
               "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -19030,32 +19030,32 @@
               "version": "1.4.1",
               "bundled": true,
               "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
               }
             },
             "flush-write-stream": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
               }
             },
             "from2": {
               "version": "2.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
               }
             },
             "parallel-transform": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
               },
               "dependencies": {
                 "cyclist": {
@@ -19068,25 +19068,25 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
               }
             },
             "pumpify": {
               "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "duplexify": "^3.5.3",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
+                "duplexify": "3.5.4",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
               },
               "dependencies": {
                 "pump": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
+                    "end-of-stream": "1.4.1",
+                    "once": "1.4.0"
                   }
                 }
               }
@@ -19095,8 +19095,8 @@
               "version": "1.2.2",
               "bundled": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -19109,8 +19109,8 @@
               "version": "2.0.3",
               "bundled": true,
               "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
               },
               "dependencies": {
                 "xtend": {
@@ -19138,24 +19138,24 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
           },
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.5",
               "bundled": true,
               "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
               },
               "dependencies": {
                 "iferr": {
@@ -19168,7 +19168,7 @@
               "version": "1.0.3",
               "bundled": true,
               "requires": {
-                "aproba": "^1.1.1"
+                "aproba": "1.2.0"
               }
             }
           }
@@ -19177,43 +19177,43 @@
           "version": "3.6.2",
           "bundled": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "glob": "^7.0.3",
-            "graceful-fs": "^4.1.2",
-            "minimatch": "^3.0.2",
-            "mkdirp": "^0.5.0",
-            "nopt": "2 || 3",
-            "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": "2",
-            "rimraf": "2",
-            "semver": "~5.3.0",
-            "tar": "^2.0.0",
-            "which": "1"
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.5",
+            "request": "2.85.0",
+            "rimraf": "2.6.2",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.3.0"
           },
           "dependencies": {
             "fstream": {
               "version": "1.0.11",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
               }
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "^1.0.0",
+                    "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -19233,7 +19233,7 @@
               "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "abbrev": "1"
+                "abbrev": "1.1.1"
               }
             },
             "semver": {
@@ -19244,16 +19244,16 @@
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
               },
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
                   "bundled": true,
                   "requires": {
-                    "inherits": "~2.0.0"
+                    "inherits": "2.0.3"
                   }
                 }
               }
@@ -19264,25 +19264,25 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
           },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "builtin-modules": "^1.0.0"
+                "builtin-modules": "1.1.1"
               },
               "dependencies": {
                 "builtin-modules": {
@@ -19297,8 +19297,8 @@
           "version": "1.0.8",
           "bundled": true,
           "requires": {
-            "cli-table2": "^0.2.0",
-            "console-control-strings": "^1.1.0"
+            "cli-table2": "0.2.0",
+            "console-control-strings": "1.1.0"
           },
           "dependencies": {
             "console-control-strings": {
@@ -19315,21 +19315,21 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "semver": "^2.3.0 || 3.x || 4 || 5"
+            "semver": "5.5.0"
           }
         },
         "npm-lifecycle": {
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "byline": "^5.0.0",
-            "graceful-fs": "^4.1.11",
-            "node-gyp": "^3.6.2",
-            "resolve-from": "^4.0.0",
-            "slide": "^1.1.6",
+            "byline": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "node-gyp": "3.6.2",
+            "resolve-from": "4.0.0",
+            "slide": "1.1.6",
             "uid-number": "0.0.6",
-            "umask": "^1.1.0",
-            "which": "^1.3.0"
+            "umask": "1.1.0",
+            "which": "1.3.0"
           },
           "dependencies": {
             "byline": {
@@ -19346,39 +19346,39 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.6.0",
-            "osenv": "^0.1.5",
-            "semver": "^5.5.0",
-            "validate-npm-package-name": "^3.0.0"
+            "hosted-git-info": "2.6.0",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
+            "validate-npm-package-name": "3.0.0"
           }
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           },
           "dependencies": {
             "ignore-walk": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "minimatch": "^3.0.4"
+                "minimatch": "3.0.4"
               },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "^1.1.7"
+                    "brace-expansion": "1.1.8"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -19406,47 +19406,47 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^6.0.0",
-            "semver": "^5.4.1"
+            "npm-package-arg": "6.1.0",
+            "semver": "5.5.0"
           }
         },
         "npm-profile": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "make-fetch-happen": "^2.5.0"
+            "aproba": "1.2.0",
+            "make-fetch-happen": "2.6.0"
           },
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.6.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "^3.3.0",
-                "cacache": "^10.0.0",
-                "http-cache-semantics": "^3.8.0",
-                "http-proxy-agent": "^2.0.0",
-                "https-proxy-agent": "^2.1.0",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.2.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.0.0"
+                "agentkeepalive": "3.3.0",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.0.0",
+                "https-proxy-agent": "2.1.1",
+                "lru-cache": "4.1.2",
+                "mississippi": "1.3.1",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "^1.2.1"
+                    "humanize-ms": "1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "^2.0.0"
+                        "ms": "2.1.1"
                       },
                       "dependencies": {
                         "ms": {
@@ -19461,45 +19461,45 @@
                   "version": "10.0.4",
                   "bundled": true,
                   "requires": {
-                    "bluebird": "^3.5.1",
-                    "chownr": "^1.0.1",
-                    "glob": "^7.1.2",
-                    "graceful-fs": "^4.1.11",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^2.0.0",
-                    "mkdirp": "^0.5.1",
-                    "move-concurrently": "^1.0.1",
-                    "promise-inflight": "^1.0.1",
-                    "rimraf": "^2.6.2",
-                    "ssri": "^5.2.4",
-                    "unique-filename": "^1.1.0",
-                    "y18n": "^4.0.0"
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.2",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
                   },
                   "dependencies": {
                     "mississippi": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^2.0.1",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
                       },
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.6.2",
                           "bundled": true,
                           "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
                           },
                           "dependencies": {
                             "buffer-from": {
@@ -19516,10 +19516,10 @@
                           "version": "3.5.4",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -19532,32 +19532,32 @@
                           "version": "1.4.1",
                           "bundled": true,
                           "requires": {
-                            "once": "^1.4.0"
+                            "once": "1.4.0"
                           }
                         },
                         "flush-write-stream": {
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           }
                         },
                         "from2": {
                           "version": "2.3.0",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           }
                         },
                         "parallel-transform": {
                           "version": "1.1.0",
                           "bundled": true,
                           "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           },
                           "dependencies": {
                             "cyclist": {
@@ -19570,25 +19570,25 @@
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
                           }
                         },
                         "pumpify": {
                           "version": "1.4.0",
                           "bundled": true,
                           "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
                           }
                         },
                         "stream-each": {
                           "version": "1.2.2",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -19601,8 +19601,8 @@
                           "version": "2.0.3",
                           "bundled": true,
                           "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
                           },
                           "dependencies": {
                             "xtend": {
@@ -19627,22 +19627,22 @@
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4",
-                    "debug": "2"
+                    "agent-base": "4.2.0",
+                    "debug": "2.6.9"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -19672,22 +19672,22 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^3.1.0"
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -19717,25 +19717,25 @@
                   "version": "1.3.1",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^1.0.0",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
+                    "concat-stream": "1.6.0",
+                    "duplexify": "3.5.3",
+                    "end-of-stream": "1.4.1",
+                    "flush-write-stream": "1.0.2",
+                    "from2": "2.3.0",
+                    "parallel-transform": "1.1.0",
+                    "pump": "1.0.3",
+                    "pumpify": "1.4.0",
+                    "stream-each": "1.2.2",
+                    "through2": "2.0.3"
                   },
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.6.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
-                        "typedarray": "^0.0.6"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "typedarray": "0.0.6"
                       },
                       "dependencies": {
                         "typedarray": {
@@ -19748,10 +19748,10 @@
                       "version": "3.5.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "^1.0.0",
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0",
-                        "stream-shift": "^1.0.0"
+                        "end-of-stream": "1.4.1",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6",
+                        "stream-shift": "1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -19764,32 +19764,32 @@
                       "version": "1.4.1",
                       "bundled": true,
                       "requires": {
-                        "once": "^1.4.0"
+                        "once": "1.4.0"
                       }
                     },
                     "flush-write-stream": {
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.4"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
                       }
                     },
                     "from2": {
                       "version": "2.3.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0"
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
                       }
                     },
                     "parallel-transform": {
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "cyclist": "~0.2.2",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.1.5"
+                        "cyclist": "0.2.2",
+                        "inherits": "2.0.3",
+                        "readable-stream": "2.3.6"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -19802,25 +19802,25 @@
                       "version": "1.0.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
+                        "end-of-stream": "1.4.1",
+                        "once": "1.4.0"
                       }
                     },
                     "pumpify": {
                       "version": "1.4.0",
                       "bundled": true,
                       "requires": {
-                        "duplexify": "^3.5.3",
-                        "inherits": "^2.0.3",
-                        "pump": "^2.0.0"
+                        "duplexify": "3.5.3",
+                        "inherits": "2.0.3",
+                        "pump": "2.0.1"
                       },
                       "dependencies": {
                         "pump": {
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
                           }
                         }
                       }
@@ -19829,8 +19829,8 @@
                       "version": "1.2.2",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "stream-shift": "^1.0.0"
+                        "end-of-stream": "1.4.1",
+                        "stream-shift": "1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -19843,8 +19843,8 @@
                       "version": "2.0.3",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
+                        "readable-stream": "2.3.6",
+                        "xtend": "4.0.1"
                       },
                       "dependencies": {
                         "xtend": {
@@ -19859,16 +19859,16 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.2"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "~0.4.13"
+                        "iconv-lite": "0.4.19"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -19887,8 +19887,8 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
                   },
                   "dependencies": {
                     "err-code": {
@@ -19905,22 +19905,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "socks": "^1.1.10"
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -19935,8 +19935,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "^1.1.4",
-                        "smart-buffer": "^1.0.13"
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
                       },
                       "dependencies": {
                         "ip": {
@@ -19955,7 +19955,7 @@
                   "version": "5.3.0",
                   "bundled": true,
                   "requires": {
-                    "safe-buffer": "^5.1.1"
+                    "safe-buffer": "5.1.2"
                   }
                 }
               }
@@ -19966,27 +19966,27 @@
           "version": "8.5.1",
           "bundled": true,
           "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^5.2.4"
+            "concat-stream": "1.6.1",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.85.0",
+            "retry": "0.10.1",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "ssri": "5.3.0"
           },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
               "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -20003,7 +20003,7 @@
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -20012,12 +20012,12 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "figgy-pudding": "^2.0.1",
-            "lru-cache": "^4.1.2",
-            "make-fetch-happen": "^3.0.0",
-            "npm-package-arg": "^6.0.0",
-            "safe-buffer": "^5.1.1"
+            "bluebird": "3.5.1",
+            "figgy-pudding": "2.0.1",
+            "lru-cache": "4.1.2",
+            "make-fetch-happen": "3.0.0",
+            "npm-package-arg": "6.1.0",
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
             "figgy-pudding": {
@@ -20028,31 +20028,31 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^10.0.4",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.0",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.2.4"
+                "agentkeepalive": "3.4.1",
+                "cacache": "10.0.4",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.2",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.3.0"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.4.1",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "^1.2.1"
+                    "humanize-ms": "1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "^2.0.0"
+                        "ms": "2.1.1"
                       },
                       "dependencies": {
                         "ms": {
@@ -20067,45 +20067,45 @@
                   "version": "10.0.4",
                   "bundled": true,
                   "requires": {
-                    "bluebird": "^3.5.1",
-                    "chownr": "^1.0.1",
-                    "glob": "^7.1.2",
-                    "graceful-fs": "^4.1.11",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^2.0.0",
-                    "mkdirp": "^0.5.1",
-                    "move-concurrently": "^1.0.1",
-                    "promise-inflight": "^1.0.1",
-                    "rimraf": "^2.6.2",
-                    "ssri": "^5.2.4",
-                    "unique-filename": "^1.1.0",
-                    "y18n": "^4.0.0"
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.2",
+                    "mississippi": "2.0.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "5.3.0",
+                    "unique-filename": "1.1.0",
+                    "y18n": "4.0.0"
                   },
                   "dependencies": {
                     "mississippi": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^2.0.1",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
+                        "concat-stream": "1.6.2",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.3",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "2.0.1",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
                       },
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.6.2",
                           "bundled": true,
                           "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
+                            "buffer-from": "1.0.0",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "typedarray": "0.0.6"
                           },
                           "dependencies": {
                             "buffer-from": {
@@ -20122,10 +20122,10 @@
                           "version": "3.5.4",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -20138,32 +20138,32 @@
                           "version": "1.4.1",
                           "bundled": true,
                           "requires": {
-                            "once": "^1.4.0"
+                            "once": "1.4.0"
                           }
                         },
                         "flush-write-stream": {
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           }
                         },
                         "from2": {
                           "version": "2.3.0",
                           "bundled": true,
                           "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           }
                         },
                         "parallel-transform": {
                           "version": "1.1.0",
                           "bundled": true,
                           "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
+                            "cyclist": "0.2.2",
+                            "inherits": "2.0.3",
+                            "readable-stream": "2.3.6"
                           },
                           "dependencies": {
                             "cyclist": {
@@ -20176,25 +20176,25 @@
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
+                            "end-of-stream": "1.4.1",
+                            "once": "1.4.0"
                           }
                         },
                         "pumpify": {
                           "version": "1.4.0",
                           "bundled": true,
                           "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
+                            "duplexify": "3.5.4",
+                            "inherits": "2.0.3",
+                            "pump": "2.0.1"
                           }
                         },
                         "stream-each": {
                           "version": "1.2.2",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
+                            "end-of-stream": "1.4.1",
+                            "stream-shift": "1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -20207,8 +20207,8 @@
                           "version": "2.0.3",
                           "bundled": true,
                           "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
+                            "readable-stream": "2.3.6",
+                            "xtend": "4.0.1"
                           },
                           "dependencies": {
                             "xtend": {
@@ -20233,7 +20233,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4",
+                    "agent-base": "4.2.0",
                     "debug": "3.1.0"
                   },
                   "dependencies": {
@@ -20241,14 +20241,14 @@
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -20278,22 +20278,22 @@
                   "version": "2.2.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^3.1.0"
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -20323,23 +20323,23 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.2",
+                    "safe-buffer": "5.1.2"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "~0.4.13"
+                        "iconv-lite": "0.4.21"
                       },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.21",
                           "bundled": true,
                           "requires": {
-                            "safer-buffer": "^2.1.0"
+                            "safer-buffer": "2.1.2"
                           },
                           "dependencies": {
                             "safer-buffer": {
@@ -20356,8 +20356,8 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
                   },
                   "dependencies": {
                     "err-code": {
@@ -20374,22 +20374,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "socks": "^1.1.10"
+                    "agent-base": "4.2.0",
+                    "socks": "1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -20404,8 +20404,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "^1.1.4",
-                        "smart-buffer": "^1.0.13"
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
                       },
                       "dependencies": {
                         "ip": {
@@ -20424,7 +20424,7 @@
                   "version": "5.3.0",
                   "bundled": true,
                   "requires": {
-                    "safe-buffer": "^5.1.1"
+                    "safe-buffer": "5.1.2"
                   }
                 }
               }
@@ -20439,18 +20439,18 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           },
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
               "bundled": true,
               "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.6"
               },
               "dependencies": {
                 "delegates": {
@@ -20467,14 +20467,14 @@
               "version": "2.7.4",
               "bundled": true,
               "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
               },
               "dependencies": {
                 "object-assign": {
@@ -20489,9 +20489,9 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
                   },
                   "dependencies": {
                     "code-point-at": {
@@ -20502,7 +20502,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -20517,7 +20517,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -20530,7 +20530,7 @@
                   "version": "1.1.2",
                   "bundled": true,
                   "requires": {
-                    "string-width": "^1.0.2"
+                    "string-width": "1.0.2"
                   }
                 }
               }
@@ -20545,7 +20545,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "opener": {
@@ -20556,8 +20556,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           },
           "dependencies": {
             "os-homedir": {
@@ -20574,30 +20574,30 @@
           "version": "8.1.1",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^11.0.1",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.2",
-            "make-fetch-happen": "^4.0.1",
-            "minimatch": "^3.0.4",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "normalize-package-data": "^2.4.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
-            "osenv": "^0.1.5",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.1",
-            "semver": "^5.5.0",
-            "ssri": "^6.0.0",
-            "tar": "^4.4.1",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
+            "bluebird": "3.5.1",
+            "cacache": "11.0.1",
+            "get-stream": "3.0.0",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.2",
+            "make-fetch-happen": "4.0.1",
+            "minimatch": "3.0.4",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.1.0",
+            "npm-packlist": "1.1.10",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.5",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "5.0.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.2",
+            "semver": "5.5.0",
+            "ssri": "6.0.0",
+            "tar": "4.4.2",
+            "unique-filename": "1.1.0",
+            "which": "1.3.0"
           },
           "dependencies": {
             "get-stream": {
@@ -20608,31 +20608,31 @@
               "version": "4.0.1",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^11.0.1",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^4.0.0",
-                "ssri": "^6.0.0"
+                "agentkeepalive": "3.4.1",
+                "cacache": "11.0.1",
+                "http-cache-semantics": "3.8.1",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.2",
+                "mississippi": "3.0.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "4.0.1",
+                "ssri": "6.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.4.1",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "^1.2.1"
+                    "humanize-ms": "1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "^2.0.0"
+                        "ms": "2.1.1"
                       },
                       "dependencies": {
                         "ms": {
@@ -20651,7 +20651,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4",
+                    "agent-base": "4.2.0",
                     "debug": "3.1.0"
                   },
                   "dependencies": {
@@ -20659,14 +20659,14 @@
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -20696,22 +20696,22 @@
                   "version": "2.2.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^3.1.0"
+                    "agent-base": "4.2.0",
+                    "debug": "3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -20741,23 +20741,23 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.2",
+                    "safe-buffer": "5.1.2"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "~0.4.13"
+                        "iconv-lite": "0.4.21"
                       },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.21",
                           "bundled": true,
                           "requires": {
-                            "safer-buffer": "^2.1.0"
+                            "safer-buffer": "2.1.2"
                           },
                           "dependencies": {
                             "safer-buffer": {
@@ -20774,22 +20774,22 @@
                   "version": "4.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "~4.2.0",
-                    "socks": "~2.2.0"
+                    "agent-base": "4.2.0",
+                    "socks": "2.2.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -20804,8 +20804,8 @@
                       "version": "2.2.0",
                       "bundled": true,
                       "requires": {
-                        "ip": "^1.1.5",
-                        "smart-buffer": "^4.0.1"
+                        "ip": "1.1.5",
+                        "smart-buffer": "4.0.1"
                       },
                       "dependencies": {
                         "ip": {
@@ -20826,14 +20826,14 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "^1.0.0",
+                    "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -20853,8 +20853,8 @@
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "err-code": "^1.0.0",
-                "retry": "^0.10.0"
+                "err-code": "1.1.2",
+                "retry": "0.10.1"
               },
               "dependencies": {
                 "err-code": {
@@ -20871,7 +20871,7 @@
               "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "genfun": "^4.0.1"
+                "genfun": "4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -20898,8 +20898,8 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "decode-uri-component": "^0.2.0",
-            "strict-uri-encode": "^2.0.0"
+            "decode-uri-component": "0.2.0",
+            "strict-uri-encode": "2.0.0"
           },
           "dependencies": {
             "decode-uri-component": {
@@ -20920,7 +20920,7 @@
           "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "mute-stream": "~0.0.4"
+            "mute-stream": "0.0.7"
           },
           "dependencies": {
             "mute-stream": {
@@ -20933,20 +20933,20 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2"
+            "graceful-fs": "4.1.11"
           }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "graceful-fs": "^4.1.2",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "slide": "~1.1.3",
-            "util-extend": "^1.0.1"
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.5.0",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
           },
           "dependencies": {
             "util-extend": {
@@ -20959,11 +20959,11 @@
           "version": "2.0.13",
           "bundled": true,
           "requires": {
-            "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-better-errors": "^1.0.1",
-            "normalize-package-data": "^2.0.0",
-            "slash": "^1.0.0"
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-better-errors": "1.0.1",
+            "normalize-package-data": "2.4.0",
+            "slash": "1.0.0"
           },
           "dependencies": {
             "json-parse-better-errors": {
@@ -20980,24 +20980,24 @@
           "version": "5.2.1",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.13",
+            "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           },
           "dependencies": {
             "core-util-is": {
@@ -21016,7 +21016,7 @@
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             },
             "util-deprecate": {
@@ -21029,38 +21029,38 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "graceful-fs": "^4.1.2",
-            "once": "^1.3.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
           }
         },
         "request": {
           "version": "2.85.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "hawk": "~6.0.2",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "stringstream": "~0.0.5",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
           },
           "dependencies": {
             "aws-sign2": {
@@ -21079,7 +21079,7 @@
               "version": "1.0.6",
               "bundled": true,
               "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
@@ -21100,9 +21100,9 @@
               "version": "2.3.2",
               "bundled": true,
               "requires": {
-                "asynckit": "^0.4.0",
+                "asynckit": "0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
+                "mime-types": "2.1.18"
               },
               "dependencies": {
                 "asynckit": {
@@ -21115,18 +21115,18 @@
               "version": "5.0.3",
               "bundled": true,
               "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
               },
               "dependencies": {
                 "ajv": {
                   "version": "5.5.2",
                   "bundled": true,
                   "requires": {
-                    "co": "^4.6.0",
-                    "fast-deep-equal": "^1.0.0",
-                    "fast-json-stable-stringify": "^2.0.0",
-                    "json-schema-traverse": "^0.3.0"
+                    "co": "4.6.0",
+                    "fast-deep-equal": "1.1.0",
+                    "fast-json-stable-stringify": "2.0.0",
+                    "json-schema-traverse": "0.3.1"
                   },
                   "dependencies": {
                     "co": {
@@ -21157,31 +21157,31 @@
               "version": "6.0.2",
               "bundled": true,
               "requires": {
-                "boom": "4.x.x",
-                "cryptiles": "3.x.x",
-                "hoek": "4.x.x",
-                "sntp": "2.x.x"
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
               },
               "dependencies": {
                 "boom": {
                   "version": "4.3.1",
                   "bundled": true,
                   "requires": {
-                    "hoek": "4.x.x"
+                    "hoek": "4.2.1"
                   }
                 },
                 "cryptiles": {
                   "version": "3.1.2",
                   "bundled": true,
                   "requires": {
-                    "boom": "5.x.x"
+                    "boom": "5.2.0"
                   },
                   "dependencies": {
                     "boom": {
                       "version": "5.2.0",
                       "bundled": true,
                       "requires": {
-                        "hoek": "4.x.x"
+                        "hoek": "4.2.1"
                       }
                     }
                   }
@@ -21194,7 +21194,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "hoek": "4.x.x"
+                    "hoek": "4.2.1"
                   }
                 }
               }
@@ -21203,9 +21203,9 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
               },
               "dependencies": {
                 "assert-plus": {
@@ -21234,9 +21234,9 @@
                       "version": "1.10.0",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "^1.0.0",
+                        "assert-plus": "1.0.0",
                         "core-util-is": "1.0.2",
-                        "extsprintf": "^1.2.0"
+                        "extsprintf": "1.3.0"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -21251,14 +21251,14 @@
                   "version": "1.14.1",
                   "bundled": true,
                   "requires": {
-                    "asn1": "~0.2.3",
-                    "assert-plus": "^1.0.0",
-                    "bcrypt-pbkdf": "^1.0.0",
-                    "dashdash": "^1.12.0",
-                    "ecc-jsbn": "~0.1.1",
-                    "getpass": "^0.1.1",
-                    "jsbn": "~0.1.0",
-                    "tweetnacl": "~0.14.0"
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
                   },
                   "dependencies": {
                     "asn1": {
@@ -21270,14 +21270,14 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "tweetnacl": "^0.14.3"
+                        "tweetnacl": "0.14.5"
                       }
                     },
                     "dashdash": {
                       "version": "1.14.1",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "^1.0.0"
+                        "assert-plus": "1.0.0"
                       }
                     },
                     "ecc-jsbn": {
@@ -21285,14 +21285,14 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "~0.1.0"
+                        "jsbn": "0.1.1"
                       }
                     },
                     "getpass": {
                       "version": "0.1.7",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "^1.0.0"
+                        "assert-plus": "1.0.0"
                       }
                     },
                     "jsbn": {
@@ -21325,7 +21325,7 @@
               "version": "2.1.18",
               "bundled": true,
               "requires": {
-                "mime-db": "~1.33.0"
+                "mime-db": "1.33.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -21354,7 +21354,7 @@
               "version": "2.3.4",
               "bundled": true,
               "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
               },
               "dependencies": {
                 "punycode": {
@@ -21367,7 +21367,7 @@
               "version": "0.6.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -21380,7 +21380,7 @@
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -21395,8 +21395,8 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.6"
           }
         },
         "slide": {
@@ -21411,26 +21411,26 @@
           "version": "2.1.3",
           "bundled": true,
           "requires": {
-            "from2": "^1.3.0",
-            "stream-iterate": "^1.1.0"
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
           },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.10"
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
               },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
                   "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
                     "isarray": "0.0.1",
-                    "string_decoder": "~0.10.x"
+                    "string_decoder": "0.10.31"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -21453,8 +21453,8 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "readable-stream": "^2.1.5",
-                "stream-shift": "^1.0.0"
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -21473,7 +21473,7 @@
           "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -21486,35 +21486,35 @@
           "version": "4.4.2",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.2"
           },
           "dependencies": {
             "fs-minipass": {
               "version": "1.2.5",
               "bundled": true,
               "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "2.2.4"
               }
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.1",
-                "yallist": "^3.0.0"
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
               }
             },
             "minizlib": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "2.2.4"
               }
             },
             "safe-buffer": {
@@ -21547,14 +21547,14 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "unique-slug": "^2.0.0"
+            "unique-slug": "2.0.0"
           },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "imurmurhash": "^0.1.4"
+                "imurmurhash": "0.1.4"
               }
             }
           }
@@ -21567,36 +21567,36 @@
           "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "boxen": "1.3.0",
+            "chalk": "2.4.1",
+            "configstore": "3.1.2",
+            "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
           },
           "dependencies": {
             "boxen": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "ansi-align": "^2.0.0",
-                "camelcase": "^4.0.0",
-                "chalk": "^2.0.1",
-                "cli-boxes": "^1.0.0",
-                "string-width": "^2.0.0",
-                "term-size": "^1.2.0",
-                "widest-line": "^2.0.0"
+                "ansi-align": "2.0.0",
+                "camelcase": "4.1.0",
+                "chalk": "2.4.1",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.1.1",
+                "term-size": "1.2.0",
+                "widest-line": "2.0.0"
               },
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "^2.0.0"
+                    "string-width": "2.1.1"
                   }
                 },
                 "camelcase": {
@@ -21611,8 +21611,8 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "is-fullwidth-code-point": "^2.0.0",
-                    "strip-ansi": "^4.0.0"
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -21625,36 +21625,36 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "^0.7.0"
+                    "execa": "0.7.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "^4.0.1",
-                            "shebang-command": "^1.2.0",
-                            "which": "^1.2.9"
+                            "lru-cache": "4.1.2",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
                           },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "shebang-regex": "^1.0.0"
+                                "shebang-regex": "1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -21677,7 +21677,7 @@
                           "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "^2.0.0"
+                            "path-key": "2.0.1"
                           },
                           "dependencies": {
                             "path-key": {
@@ -21706,7 +21706,7 @@
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "^2.1.1"
+                    "string-width": "2.1.1"
                   }
                 }
               }
@@ -21715,23 +21715,23 @@
               "version": "2.4.1",
               "bundled": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               },
               "dependencies": {
                 "ansi-styles": {
                   "version": "3.2.1",
                   "bundled": true,
                   "requires": {
-                    "color-convert": "^1.9.0"
+                    "color-convert": "1.9.1"
                   },
                   "dependencies": {
                     "color-convert": {
                       "version": "1.9.1",
                       "bundled": true,
                       "requires": {
-                        "color-name": "^1.1.1"
+                        "color-name": "1.1.3"
                       },
                       "dependencies": {
                         "color-name": {
@@ -21750,7 +21750,7 @@
                   "version": "5.4.0",
                   "bundled": true,
                   "requires": {
-                    "has-flag": "^3.0.0"
+                    "has-flag": "3.0.0"
                   },
                   "dependencies": {
                     "has-flag": {
@@ -21765,19 +21765,19 @@
               "version": "3.1.2",
               "bundled": true,
               "requires": {
-                "dot-prop": "^4.1.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^1.0.0",
-                "unique-string": "^1.0.0",
-                "write-file-atomic": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
+                "dot-prop": "4.2.0",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.2.0",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "2.3.0",
+                "xdg-basedir": "3.0.0"
               },
               "dependencies": {
                 "dot-prop": {
                   "version": "4.2.0",
                   "bundled": true,
                   "requires": {
-                    "is-obj": "^1.0.0"
+                    "is-obj": "1.0.1"
                   },
                   "dependencies": {
                     "is-obj": {
@@ -21790,7 +21790,7 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "pify": "^3.0.0"
+                    "pify": "3.0.0"
                   },
                   "dependencies": {
                     "pify": {
@@ -21803,7 +21803,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "crypto-random-string": "^1.0.0"
+                    "crypto-random-string": "1.0.0"
                   },
                   "dependencies": {
                     "crypto-random-string": {
@@ -21822,7 +21822,7 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "ci-info": "^1.0.0"
+                "ci-info": "1.1.3"
               },
               "dependencies": {
                 "ci-info": {
@@ -21835,22 +21835,22 @@
               "version": "0.1.0",
               "bundled": true,
               "requires": {
-                "global-dirs": "^0.1.0",
-                "is-path-inside": "^1.0.0"
+                "global-dirs": "0.1.1",
+                "is-path-inside": "1.0.1"
               },
               "dependencies": {
                 "global-dirs": {
                   "version": "0.1.1",
                   "bundled": true,
                   "requires": {
-                    "ini": "^1.3.4"
+                    "ini": "1.3.5"
                   }
                 },
                 "is-path-inside": {
                   "version": "1.0.1",
                   "bundled": true,
                   "requires": {
-                    "path-is-inside": "^1.0.1"
+                    "path-is-inside": "1.0.2"
                   }
                 }
               }
@@ -21863,41 +21863,41 @@
               "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "package-json": "^4.0.0"
+                "package-json": "4.0.1"
               },
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
                   "bundled": true,
                   "requires": {
-                    "got": "^6.7.1",
-                    "registry-auth-token": "^3.0.1",
-                    "registry-url": "^3.0.3",
-                    "semver": "^5.1.0"
+                    "got": "6.7.1",
+                    "registry-auth-token": "3.3.2",
+                    "registry-url": "3.1.0",
+                    "semver": "5.5.0"
                   },
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
                       "bundled": true,
                       "requires": {
-                        "create-error-class": "^3.0.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^3.0.0",
-                        "is-redirect": "^1.0.0",
-                        "is-retry-allowed": "^1.0.0",
-                        "is-stream": "^1.0.0",
-                        "lowercase-keys": "^1.0.0",
-                        "safe-buffer": "^5.0.1",
-                        "timed-out": "^4.0.0",
-                        "unzip-response": "^2.0.1",
-                        "url-parse-lax": "^1.0.0"
+                        "create-error-class": "3.0.2",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.1",
+                        "safe-buffer": "5.1.2",
+                        "timed-out": "4.0.1",
+                        "unzip-response": "2.0.1",
+                        "url-parse-lax": "1.0.0"
                       },
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
                           "bundled": true,
                           "requires": {
-                            "capture-stack-trace": "^1.0.0"
+                            "capture-stack-trace": "1.0.0"
                           },
                           "dependencies": {
                             "capture-stack-trace": {
@@ -21942,7 +21942,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "requires": {
-                            "prepend-http": "^1.0.1"
+                            "prepend-http": "1.0.4"
                           },
                           "dependencies": {
                             "prepend-http": {
@@ -21957,18 +21957,18 @@
                       "version": "3.3.2",
                       "bundled": true,
                       "requires": {
-                        "rc": "^1.1.6",
-                        "safe-buffer": "^5.0.1"
+                        "rc": "1.2.7",
+                        "safe-buffer": "5.1.2"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.7",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "^0.5.1",
-                            "ini": "~1.3.0",
-                            "minimist": "^1.2.0",
-                            "strip-json-comments": "~2.0.1"
+                            "deep-extend": "0.5.1",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -21991,17 +21991,17 @@
                       "version": "3.1.0",
                       "bundled": true,
                       "requires": {
-                        "rc": "^1.0.1"
+                        "rc": "1.2.7"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.7",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "^0.5.1",
-                            "ini": "~1.3.0",
-                            "minimist": "^1.2.0",
-                            "strip-json-comments": "~2.0.1"
+                            "deep-extend": "0.5.1",
+                            "ini": "1.3.5",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -22028,7 +22028,7 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "semver": "^5.0.3"
+                "semver": "5.5.0"
               }
             },
             "xdg-basedir": {
@@ -22045,16 +22045,16 @@
           "version": "3.0.3",
           "bundled": true,
           "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
           },
           "dependencies": {
             "spdx-correct": {
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
               },
               "dependencies": {
                 "spdx-license-ids": {
@@ -22067,8 +22067,8 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
               },
               "dependencies": {
                 "spdx-exceptions": {
@@ -22087,7 +22087,7 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "^1.0.3"
+            "builtins": "1.0.3"
           },
           "dependencies": {
             "builtins": {
@@ -22100,7 +22100,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           },
           "dependencies": {
             "isexe": {
@@ -22113,14 +22113,14 @@
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "errno": "~0.1.7"
+            "errno": "0.1.7"
           },
           "dependencies": {
             "errno": {
               "version": "0.1.7",
               "bundled": true,
               "requires": {
-                "prr": "~1.0.1"
+                "prr": "1.0.1"
               },
               "dependencies": {
                 "prr": {
@@ -22139,9 +22139,9 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
           },
           "dependencies": {
             "signal-exit": {
@@ -22158,9 +22158,9 @@
       "integrity": "sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=",
       "dev": true,
       "requires": {
-        "rc": "^1.1.0",
-        "shellsubstitute": "^1.1.0",
-        "untildify": "^2.1.0"
+        "rc": "1.2.7",
+        "shellsubstitute": "1.2.0",
+        "untildify": "2.1.0"
       }
     },
     "npm-run-path": {
@@ -22168,7 +22168,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npmlog": {
@@ -22176,9 +22176,9 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz",
       "integrity": "sha1-Ag+ZNR8MAuOZxnS6JW58TTs90pg=",
       "requires": {
-        "ansi": "~0.3.1",
-        "are-we-there-yet": "~1.1.2",
-        "gauge": "~1.2.5"
+        "ansi": "0.3.1",
+        "are-we-there-yet": "1.1.4",
+        "gauge": "1.2.7"
       }
     },
     "nprogress": {
@@ -22191,7 +22191,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "null-loader": {
@@ -22245,9 +22245,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -22255,7 +22255,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -22275,7 +22275,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -22291,10 +22291,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.11"
       }
     },
     "object.defaults": {
@@ -22302,10 +22302,10 @@
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -22313,7 +22313,7 @@
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "isobject": {
@@ -22328,8 +22328,8 @@
       "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -22337,7 +22337,7 @@
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -22347,8 +22347,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -22356,7 +22356,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -22384,7 +22384,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onecolor": {
@@ -22397,7 +22397,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "open": {
@@ -22415,7 +22415,7 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "requires": {
-        "is-wsl": "^1.1.0"
+        "is-wsl": "1.1.0"
       }
     },
     "optimist": {
@@ -22423,8 +22423,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -22440,12 +22440,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -22462,9 +22462,9 @@
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "dev": true,
       "requires": {
-        "end-of-stream": "~0.1.5",
-        "sequencify": "~0.0.7",
-        "stream-consume": "~0.1.0"
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.1"
       },
       "dependencies": {
         "end-of-stream": {
@@ -22473,7 +22473,7 @@
           "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
           "dev": true,
           "requires": {
-            "once": "~1.3.0"
+            "once": "1.3.3"
           }
         },
         "once": {
@@ -22482,7 +22482,7 @@
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         }
       }
@@ -22492,8 +22492,8 @@
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "requires": {
-        "is-stream": "^1.0.1",
-        "readable-stream": "^2.0.1"
+        "is-stream": "1.1.0",
+        "readable-stream": "2.3.6"
       }
     },
     "original": {
@@ -22501,7 +22501,7 @@
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
       "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
       "requires": {
-        "url-parse": "1.0.x"
+        "url-parse": "1.0.5"
       },
       "dependencies": {
         "url-parse": {
@@ -22509,8 +22509,8 @@
           "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
           "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
           "requires": {
-            "querystringify": "0.0.x",
-            "requires-port": "1.0.x"
+            "querystringify": "0.0.4",
+            "requires-port": "1.0.0"
           }
         }
       }
@@ -22535,9 +22535,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       },
       "dependencies": {
         "execa": {
@@ -22545,13 +22545,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         }
       }
@@ -22566,9 +22566,9 @@
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "requires": {
-        "graceful-fs": "^4.1.4",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.1.0"
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "p-cancelable": {
@@ -22586,7 +22586,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -22594,7 +22594,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-map": {
@@ -22612,7 +22612,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "p-try": {
@@ -22625,10 +22625,10 @@
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
       }
     },
     "pako": {
@@ -22641,11 +22641,11 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.16"
       }
     },
     "parse-bmfont-ascii": {
@@ -22663,8 +22663,8 @@
       "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz",
       "integrity": "sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=",
       "requires": {
-        "xml-parse-from-string": "^1.0.0",
-        "xml2js": "^0.4.5"
+        "xml-parse-from-string": "1.0.1",
+        "xml2js": "0.4.19"
       }
     },
     "parse-english": {
@@ -22672,10 +22672,10 @@
       "resolved": "https://registry.npmjs.org/parse-english/-/parse-english-4.1.1.tgz",
       "integrity": "sha512-g7hegR9AFIlGXl5645mG8nQeeWW7SrK7lgmgIWR0KKWvGyZO5mxa4GGoNxRLm6VW2LGpLnn6g4O9yyLJQ4IzQw==",
       "requires": {
-        "nlcst-to-string": "^2.0.0",
-        "parse-latin": "^4.0.0",
-        "unist-util-modify-children": "^1.0.0",
-        "unist-util-visit-children": "^1.0.0"
+        "nlcst-to-string": "2.0.2",
+        "parse-latin": "4.1.1",
+        "unist-util-modify-children": "1.1.2",
+        "unist-util-visit-children": "1.1.2"
       }
     },
     "parse-entities": {
@@ -22683,12 +22683,12 @@
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
       "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
       "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities": "1.2.2",
+        "character-entities-legacy": "1.1.2",
+        "character-reference-invalid": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-decimal": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "parse-filepath": {
@@ -22696,9 +22696,9 @@
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-glob": {
@@ -22706,10 +22706,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-headers": {
@@ -22717,7 +22717,7 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "requires": {
-        "for-each": "^0.3.2",
+        "for-each": "0.3.2",
         "trim": "0.0.1"
       }
     },
@@ -22726,7 +22726,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-latin": {
@@ -22734,9 +22734,9 @@
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-4.1.1.tgz",
       "integrity": "sha512-9fPVvDdw6G8LxL3o/PL6IzSGNGpF+3HEjCzFe0dN83sZPstftyr+McP9dNi3+EnR7ICYOHbHKCZ0l7JD90K5xQ==",
       "requires": {
-        "nlcst-to-string": "^2.0.0",
-        "unist-util-modify-children": "^1.0.0",
-        "unist-util-visit-children": "^1.0.0"
+        "nlcst-to-string": "2.0.2",
+        "unist-util-modify-children": "1.1.2",
+        "unist-util-visit-children": "1.1.2"
       }
     },
     "parse-numeric-range": {
@@ -22754,7 +22754,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "7.0.64"
       }
     },
     "parseqs": {
@@ -22762,7 +22762,7 @@
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -22770,7 +22770,7 @@
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -22829,7 +22829,7 @@
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -22847,7 +22847,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -22862,11 +22862,11 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
       "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "pbkdf2-compat": {
@@ -22899,7 +22899,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pipetteur": {
@@ -22908,8 +22908,8 @@
       "integrity": "sha1-GVV2CVno0aEcsqUOyD7sRwYz5J8=",
       "dev": true,
       "requires": {
-        "onecolor": "^3.0.4",
-        "synesthesia": "^1.0.1"
+        "onecolor": "3.0.5",
+        "synesthesia": "1.0.1"
       },
       "dependencies": {
         "onecolor": {
@@ -22925,7 +22925,7 @@
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
       "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
       "requires": {
-        "pngjs": "^3.0.0"
+        "pngjs": "3.3.3"
       }
     },
     "pixrem": {
@@ -22933,9 +22933,9 @@
       "resolved": "https://registry.npmjs.org/pixrem/-/pixrem-3.0.2.tgz",
       "integrity": "sha1-MNG6+0w73Ojpu0vVahOYVhkyDDQ=",
       "requires": {
-        "browserslist": "^1.0.0",
-        "postcss": "^5.0.0",
-        "reduce-css-calc": "^1.2.7"
+        "browserslist": "1.7.7",
+        "postcss": "5.2.18",
+        "reduce-css-calc": "1.3.0"
       },
       "dependencies": {
         "browserslist": {
@@ -22943,8 +22943,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000839",
+            "electron-to-chromium": "1.3.45"
           }
         }
       }
@@ -22954,10 +22954,10 @@
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
       "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
       "requires": {
-        "find-up": "^1.0.0",
-        "load-json-file": "^1.1.0",
-        "object-assign": "^4.0.1",
-        "symbol": "^0.2.1"
+        "find-up": "1.1.2",
+        "load-json-file": "1.1.0",
+        "object-assign": "4.1.1",
+        "symbol": "0.2.3"
       },
       "dependencies": {
         "load-json-file": {
@@ -22965,11 +22965,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "pify": {
@@ -22982,7 +22982,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -22992,7 +22992,7 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       }
     },
     "pkg-resolve": {
@@ -23001,8 +23001,8 @@
       "integrity": "sha1-Mpsudsy7Ny4i5qOkHLMKsEV4Nro=",
       "optional": true,
       "requires": {
-        "jspm": "^0.17.0-beta.13",
-        "resolve": "^1.1.7"
+        "jspm": "0.17.0-beta.48",
+        "resolve": "1.7.1"
       }
     },
     "pleeease-filters": {
@@ -23010,8 +23010,8 @@
       "resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-3.0.1.tgz",
       "integrity": "sha1-Tf4OjxBGYTUXxktyi8gGCKfr8i8=",
       "requires": {
-        "onecolor": "~2.4.0",
-        "postcss": "^5.0.4"
+        "onecolor": "2.4.2",
+        "postcss": "5.2.18"
       }
     },
     "plur": {
@@ -23020,7 +23020,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "pluralize": {
@@ -23039,9 +23039,9 @@
       "resolved": "https://registry.npmjs.org/pngquant-bin/-/pngquant-bin-3.1.1.tgz",
       "integrity": "sha1-0STZinWpSH9AwWQLTb/Lsr1aH9E=",
       "requires": {
-        "bin-build": "^2.0.0",
-        "bin-wrapper": "^3.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "posix-character-classes": {
@@ -23054,10 +23054,10 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
       "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
       "requires": {
-        "chalk": "^1.1.3",
-        "js-base64": "^2.1.9",
-        "source-map": "^0.5.6",
-        "supports-color": "^3.2.3"
+        "chalk": "1.1.3",
+        "js-base64": "2.4.3",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "supports-color": {
@@ -23065,7 +23065,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23075,8 +23075,8 @@
       "resolved": "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.3.0.tgz",
       "integrity": "sha1-ovN8W9+ogeTBX08kXsDNlt0ucNU=",
       "requires": {
-        "balanced-match": "^0.4.1",
-        "postcss": "^5.0.21"
+        "balanced-match": "0.4.2",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -23091,8 +23091,8 @@
       "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-1.0.1.tgz",
       "integrity": "sha1-zrc3d+EGFn6yM/GTjJvZ8uaXMI0=",
       "requires": {
-        "postcss": "^5.1.1",
-        "postcss-selector-parser": "^2.2.0"
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
       }
     },
     "postcss-browser-reporter": {
@@ -23100,7 +23100,7 @@
       "resolved": "https://registry.npmjs.org/postcss-browser-reporter/-/postcss-browser-reporter-0.5.0.tgz",
       "integrity": "sha1-rgad0IbVc4jRluHaw5y412Jv60g=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-calc": {
@@ -23108,9 +23108,9 @@
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "requires": {
-        "postcss": "^5.0.2",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-css-calc": "^1.2.6"
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
       }
     },
     "postcss-color-function": {
@@ -23118,10 +23118,10 @@
       "resolved": "https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-2.0.1.tgz",
       "integrity": "sha1-mtIm9VDop8f4uKd4YFRbbdf1UkE=",
       "requires": {
-        "css-color-function": "^1.2.0",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0",
-        "postcss-value-parser": "^3.3.0"
+        "css-color-function": "1.3.3",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-color-gray": {
@@ -23129,10 +23129,10 @@
       "resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-3.0.1.tgz",
       "integrity": "sha1-dEMu3mbdg7HRNjVlxos3bhj/Z3A=",
       "requires": {
-        "color": "^0.11.3",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-function-call": "^1.0.1"
+        "color": "0.11.4",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-function-call": "1.0.2"
       }
     },
     "postcss-color-hex-alpha": {
@@ -23140,9 +23140,9 @@
       "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-2.0.0.tgz",
       "integrity": "sha1-RP1uyt5mAoZIyIHLZQTNy/3GzQk=",
       "requires": {
-        "color": "^0.10.1",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0"
+        "color": "0.10.1",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0"
       },
       "dependencies": {
         "color": {
@@ -23150,8 +23150,8 @@
           "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
           "integrity": "sha1-wEGI34KiCd3rzOzazT7DIPGTc58=",
           "requires": {
-            "color-convert": "^0.5.3",
-            "color-string": "^0.3.0"
+            "color-convert": "0.5.3",
+            "color-string": "0.3.0"
           }
         },
         "color-convert": {
@@ -23166,9 +23166,9 @@
       "resolved": "https://registry.npmjs.org/postcss-color-hsl/-/postcss-color-hsl-1.0.5.tgz",
       "integrity": "sha1-9Tuxw0gxDOMHrYnjGBqGRzi15oc=",
       "requires": {
-        "postcss": "^5.2.0",
-        "postcss-value-parser": "^3.3.0",
-        "units-css": "^0.4.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "units-css": "0.4.0"
       }
     },
     "postcss-color-hwb": {
@@ -23176,10 +23176,10 @@
       "resolved": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-2.0.1.tgz",
       "integrity": "sha1-1jr6+bcMtZX5AKKcn+V78qMvq+w=",
       "requires": {
-        "color": "^0.11.4",
-        "postcss": "^5.0.4",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-function-call": "^1.0.1"
+        "color": "0.11.4",
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-function-call": "1.0.2"
       }
     },
     "postcss-color-rebeccapurple": {
@@ -23187,8 +23187,8 @@
       "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-2.0.1.tgz",
       "integrity": "sha1-dMZETny7fYVhO19yht96SRYIRRw=",
       "requires": {
-        "color": "^0.11.4",
-        "postcss": "^5.0.4"
+        "color": "0.11.4",
+        "postcss": "5.2.18"
       }
     },
     "postcss-color-rgb": {
@@ -23196,8 +23196,8 @@
       "resolved": "https://registry.npmjs.org/postcss-color-rgb/-/postcss-color-rgb-1.1.4.tgz",
       "integrity": "sha1-8pJD4i6OjBNDRHQJI3LUzmBb6Lw=",
       "requires": {
-        "postcss": "^5.2.0",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-color-rgba-fallback": {
@@ -23205,9 +23205,9 @@
       "resolved": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-2.2.0.tgz",
       "integrity": "sha1-bSlJG+WZCpMXPUfnx29YELCUAro=",
       "requires": {
-        "postcss": "^5.0.0",
-        "postcss-value-parser": "^3.0.2",
-        "rgb-hex": "^1.0.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "rgb-hex": "1.0.0"
       }
     },
     "postcss-colormin": {
@@ -23215,9 +23215,9 @@
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "requires": {
-        "colormin": "^1.0.5",
-        "postcss": "^5.0.13",
-        "postcss-value-parser": "^3.2.3"
+        "colormin": "1.1.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-convert-values": {
@@ -23225,8 +23225,8 @@
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "requires": {
-        "postcss": "^5.0.11",
-        "postcss-value-parser": "^3.1.2"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-cssnext": {
@@ -23234,37 +23234,37 @@
       "resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-2.11.0.tgz",
       "integrity": "sha1-MeaPAB5AlgTacDtm3hS4uMjJ8rE=",
       "requires": {
-        "autoprefixer": "^6.0.2",
-        "caniuse-api": "^1.5.3",
-        "chalk": "^1.1.1",
-        "pixrem": "^3.0.0",
-        "pleeease-filters": "^3.0.0",
-        "postcss": "^5.0.4",
-        "postcss-apply": "^0.3.0",
-        "postcss-attribute-case-insensitive": "^1.0.1",
-        "postcss-calc": "^5.0.0",
-        "postcss-color-function": "^2.0.0",
-        "postcss-color-gray": "^3.0.0",
-        "postcss-color-hex-alpha": "^2.0.0",
-        "postcss-color-hsl": "^1.0.5",
-        "postcss-color-hwb": "^2.0.0",
-        "postcss-color-rebeccapurple": "^2.0.0",
-        "postcss-color-rgb": "^1.1.4",
-        "postcss-color-rgba-fallback": "^2.0.0",
-        "postcss-custom-media": "^5.0.0",
-        "postcss-custom-properties": "^5.0.0",
-        "postcss-custom-selectors": "^3.0.0",
-        "postcss-font-family-system-ui": "^1.0.1",
-        "postcss-font-variant": "^2.0.0",
-        "postcss-image-set-polyfill": "^0.3.3",
-        "postcss-initial": "^1.3.1",
-        "postcss-media-minmax": "^2.1.0",
-        "postcss-nesting": "^2.0.5",
-        "postcss-pseudo-class-any-link": "^1.0.0",
-        "postcss-pseudoelements": "^3.0.0",
-        "postcss-replace-overflow-wrap": "^1.0.0",
-        "postcss-selector-matches": "^2.0.0",
-        "postcss-selector-not": "^2.0.0"
+        "autoprefixer": "6.7.7",
+        "caniuse-api": "1.6.1",
+        "chalk": "1.1.3",
+        "pixrem": "3.0.2",
+        "pleeease-filters": "3.0.1",
+        "postcss": "5.2.18",
+        "postcss-apply": "0.3.0",
+        "postcss-attribute-case-insensitive": "1.0.1",
+        "postcss-calc": "5.3.1",
+        "postcss-color-function": "2.0.1",
+        "postcss-color-gray": "3.0.1",
+        "postcss-color-hex-alpha": "2.0.0",
+        "postcss-color-hsl": "1.0.5",
+        "postcss-color-hwb": "2.0.1",
+        "postcss-color-rebeccapurple": "2.0.1",
+        "postcss-color-rgb": "1.1.4",
+        "postcss-color-rgba-fallback": "2.2.0",
+        "postcss-custom-media": "5.0.1",
+        "postcss-custom-properties": "5.0.2",
+        "postcss-custom-selectors": "3.0.0",
+        "postcss-font-family-system-ui": "1.0.2",
+        "postcss-font-variant": "2.0.1",
+        "postcss-image-set-polyfill": "0.3.5",
+        "postcss-initial": "1.5.3",
+        "postcss-media-minmax": "2.1.2",
+        "postcss-nesting": "2.3.1",
+        "postcss-pseudo-class-any-link": "1.0.0",
+        "postcss-pseudoelements": "3.0.0",
+        "postcss-replace-overflow-wrap": "1.0.0",
+        "postcss-selector-matches": "2.0.5",
+        "postcss-selector-not": "2.0.0"
       }
     },
     "postcss-custom-media": {
@@ -23272,7 +23272,7 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-5.0.1.tgz",
       "integrity": "sha1-E40loYS/LrVN4S1VpsAcMKnYvYE=",
       "requires": {
-        "postcss": "^5.0.0"
+        "postcss": "5.2.18"
       }
     },
     "postcss-custom-properties": {
@@ -23280,8 +23280,8 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-5.0.2.tgz",
       "integrity": "sha1-lxnXjy2pz59TgQrrwj1GVhMKzrE=",
       "requires": {
-        "balanced-match": "^0.4.2",
-        "postcss": "^5.0.0"
+        "balanced-match": "0.4.2",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -23296,9 +23296,9 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-3.0.0.tgz",
       "integrity": "sha1-j4Ekn17Qeo0JF89qOf5bBWt/lqw=",
       "requires": {
-        "balanced-match": "^0.2.0",
-        "postcss": "^5.0.0",
-        "postcss-selector-matches": "^2.0.0"
+        "balanced-match": "0.2.1",
+        "postcss": "5.2.18",
+        "postcss-selector-matches": "2.0.5"
       },
       "dependencies": {
         "balanced-match": {
@@ -23313,7 +23313,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "requires": {
-        "postcss": "^5.0.14"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-duplicates": {
@@ -23321,7 +23321,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-empty": {
@@ -23329,7 +23329,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "requires": {
-        "postcss": "^5.0.14"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-overridden": {
@@ -23337,7 +23337,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "requires": {
-        "postcss": "^5.0.16"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-unused": {
@@ -23345,8 +23345,8 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "requires": {
-        "postcss": "^5.0.14",
-        "uniqs": "^2.0.0"
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-filter-plugins": {
@@ -23354,8 +23354,8 @@
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
       "requires": {
-        "postcss": "^5.0.4",
-        "uniqid": "^4.0.0"
+        "postcss": "5.2.18",
+        "uniqid": "4.1.1"
       }
     },
     "postcss-font-family-system-ui": {
@@ -23363,9 +23363,9 @@
       "resolved": "https://registry.npmjs.org/postcss-font-family-system-ui/-/postcss-font-family-system-ui-1.0.2.tgz",
       "integrity": "sha1-PhpeP7fjHl6ecUOcyw6AFFVpJ8c=",
       "requires": {
-        "lodash": "^4.17.4",
-        "postcss": "^5.2.12",
-        "postcss-value-parser": "^3.3.0"
+        "lodash": "4.17.10",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-font-variant": {
@@ -23373,7 +23373,7 @@
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-2.0.1.tgz",
       "integrity": "sha1-fKKRA/WfoCyjrOLKIrL3VoU9Tvg=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-html": {
@@ -23382,9 +23382,9 @@
       "integrity": "sha512-KxKUpj7AY7nlCbLcTOYxdfJnGE7QFAfU2n95ADj1Q90RM/pOLdz8k3n4avOyRFs7MDQHcRzJQWM1dehCwJxisQ==",
       "dev": true,
       "requires": {
-        "htmlparser2": "^3.9.2",
-        "remark": "^8.0.0",
-        "unist-util-find-all-after": "^1.0.1"
+        "htmlparser2": "3.9.2",
+        "remark": "8.0.0",
+        "unist-util-find-all-after": "1.0.2"
       },
       "dependencies": {
         "domhandler": {
@@ -23393,7 +23393,7 @@
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "dev": true,
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "htmlparser2": {
@@ -23402,12 +23402,12 @@
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "dev": true,
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.2",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "remark": {
@@ -23416,9 +23416,9 @@
           "integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
           "dev": true,
           "requires": {
-            "remark-parse": "^4.0.0",
-            "remark-stringify": "^4.0.0",
-            "unified": "^6.0.0"
+            "remark-parse": "4.0.0",
+            "remark-stringify": "4.0.0",
+            "unified": "6.2.0"
           }
         }
       }
@@ -23428,8 +23428,8 @@
       "resolved": "https://registry.npmjs.org/postcss-image-set-polyfill/-/postcss-image-set-polyfill-0.3.5.tgz",
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "requires": {
-        "postcss": "^6.0.1",
-        "postcss-media-query-parser": "^0.2.3"
+        "postcss": "6.0.22",
+        "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -23437,7 +23437,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -23445,9 +23445,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -23460,9 +23460,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -23475,7 +23475,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -23485,13 +23485,13 @@
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-8.2.0.tgz",
       "integrity": "sha1-+S/SRU4h7077HnXADEesA/TROXw=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "pkg-resolve": "^0.1.7",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3",
-        "promise-each": "^2.2.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
+        "object-assign": "4.1.1",
+        "pkg-resolve": "0.1.14",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "promise-each": "2.2.0",
+        "read-cache": "1.0.0",
+        "resolve": "1.7.1"
       }
     },
     "postcss-initial": {
@@ -23499,8 +23499,8 @@
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-1.5.3.tgz",
       "integrity": "sha1-IMPpHJaCLdsb7UlQjbltVrrDd9A=",
       "requires": {
-        "lodash.template": "^4.2.4",
-        "postcss": "^5.0.19"
+        "lodash.template": "4.4.0",
+        "postcss": "5.2.18"
       }
     },
     "postcss-less": {
@@ -23508,7 +23508,7 @@
       "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.5.tgz",
       "integrity": "sha512-QQIiIqgEjNnquc0d4b6HDOSFZxbFQoy4MPpli2lSLpKhMyBkKwwca2HFqu4xzxlKID/F2fxSOowwtKpgczhF7A==",
       "requires": {
-        "postcss": "^5.2.16"
+        "postcss": "5.2.18"
       }
     },
     "postcss-loader": {
@@ -23516,8 +23516,8 @@
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-0.13.0.tgz",
       "integrity": "sha1-cv2vDSlETfd9N1HOTmncQLyZ7YU=",
       "requires": {
-        "loader-utils": "^0.2.15",
-        "postcss": "^5.2.0"
+        "loader-utils": "0.2.17",
+        "postcss": "5.2.18"
       }
     },
     "postcss-media-minmax": {
@@ -23525,7 +23525,7 @@
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-2.1.2.tgz",
       "integrity": "sha1-RExc+JJqteT9iiUJ6Sl+dRZJzfg=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-media-query-parser": {
@@ -23538,9 +23538,9 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.10",
-        "postcss-value-parser": "^3.1.1"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-merge-longhand": {
@@ -23548,7 +23548,7 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-merge-rules": {
@@ -23556,11 +23556,11 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "requires": {
-        "browserslist": "^1.5.2",
-        "caniuse-api": "^1.5.2",
-        "postcss": "^5.0.4",
-        "postcss-selector-parser": "^2.2.2",
-        "vendors": "^1.0.0"
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.2"
       },
       "dependencies": {
         "browserslist": {
@@ -23568,8 +23568,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000839",
+            "electron-to-chromium": "1.3.45"
           }
         }
       }
@@ -23584,9 +23584,9 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.2"
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-minify-gradients": {
@@ -23594,8 +23594,8 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "requires": {
-        "postcss": "^5.0.12",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-minify-params": {
@@ -23603,10 +23603,10 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "requires": {
-        "alphanum-sort": "^1.0.1",
-        "postcss": "^5.0.2",
-        "postcss-value-parser": "^3.0.2",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-minify-selectors": {
@@ -23614,10 +23614,10 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "requires": {
-        "alphanum-sort": "^1.0.2",
-        "has": "^1.0.1",
-        "postcss": "^5.0.14",
-        "postcss-selector-parser": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
       }
     },
     "postcss-modules-extract-imports": {
@@ -23625,7 +23625,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -23633,7 +23633,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -23641,9 +23641,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -23656,9 +23656,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -23671,7 +23671,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -23681,8 +23681,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -23690,7 +23690,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -23698,9 +23698,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -23713,9 +23713,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -23728,7 +23728,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -23738,8 +23738,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -23747,7 +23747,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -23755,9 +23755,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -23770,9 +23770,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -23785,7 +23785,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -23795,8 +23795,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "requires": {
-        "icss-replace-symbols": "^1.1.0",
-        "postcss": "^6.0.1"
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -23804,7 +23804,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -23812,9 +23812,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -23827,9 +23827,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -23842,7 +23842,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -23852,7 +23852,7 @@
       "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-2.3.1.tgz",
       "integrity": "sha1-lKa2pO9wf77CCof+5clXdZtOAc8=",
       "requires": {
-        "postcss": "^5.0.19"
+        "postcss": "5.2.18"
       }
     },
     "postcss-normalize-charset": {
@@ -23860,7 +23860,7 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "requires": {
-        "postcss": "^5.0.5"
+        "postcss": "5.2.18"
       }
     },
     "postcss-normalize-url": {
@@ -23868,10 +23868,10 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "requires": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^1.4.0",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3"
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-ordered-values": {
@@ -23879,8 +23879,8 @@
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "requires": {
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.1"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-pseudo-class-any-link": {
@@ -23888,8 +23888,8 @@
       "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-1.0.0.tgz",
       "integrity": "sha1-kDI5GWQB0zX+c6x1YYb6YuaTryY=",
       "requires": {
-        "postcss": "^5.0.3",
-        "postcss-selector-parser": "^1.1.4"
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "1.3.3"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -23897,9 +23897,9 @@
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
           "integrity": "sha1-0u4Z33pk+O8hwacchvfUg1yIwoE=",
           "requires": {
-            "flatten": "^1.0.2",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "flatten": "1.0.2",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         }
       }
@@ -23909,7 +23909,7 @@
       "resolved": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-3.0.0.tgz",
       "integrity": "sha1-bGghd8eQC6BTtt8X+MWQKEx7i7w=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-reduce-idents": {
@@ -23917,8 +23917,8 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "requires": {
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.2"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-reduce-initial": {
@@ -23926,7 +23926,7 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-reduce-transforms": {
@@ -23934,9 +23934,9 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.8",
-        "postcss-value-parser": "^3.0.1"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-replace-overflow-wrap": {
@@ -23944,7 +23944,7 @@
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-1.0.0.tgz",
       "integrity": "sha1-8KA7Meq5Y2ppNr/SEOKu8bQ0pkM=",
       "requires": {
-        "postcss": "^5.0.16"
+        "postcss": "5.2.18"
       }
     },
     "postcss-reporter": {
@@ -23952,10 +23952,10 @@
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-1.4.1.tgz",
       "integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
       "requires": {
-        "chalk": "^1.0.0",
-        "lodash": "^4.1.0",
-        "log-symbols": "^1.0.2",
-        "postcss": "^5.0.0"
+        "chalk": "1.1.3",
+        "lodash": "4.17.10",
+        "log-symbols": "1.0.2",
+        "postcss": "5.2.18"
       }
     },
     "postcss-resolve-nested-selector": {
@@ -23970,7 +23970,7 @@
       "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.6"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -23979,7 +23979,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -23988,9 +23988,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -24005,9 +24005,9 @@
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -24022,7 +24022,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -24033,8 +24033,8 @@
       "integrity": "sha512-cUmYzkP747fPCQE6d+CH2l1L4VSyIlAzZsok3HPjb5Gzsq3jE+VjpAdGlPsnQ310WKWI42sw+ar0UNN59/f3hg==",
       "dev": true,
       "requires": {
-        "gonzales-pe": "^4.0.3",
-        "postcss": "^6.0.6"
+        "gonzales-pe": "4.2.3",
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -24043,7 +24043,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -24052,9 +24052,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -24069,9 +24069,9 @@
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -24086,7 +24086,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -24097,7 +24097,7 @@
       "integrity": "sha512-gJB1tKYMkBy0MU+COt6WXA4ZiRctAKoWLa6qD7a6bbEbBMqrpa/BhfQdN80eYMV+JkKddZVEpZlOggnGShpvyg==",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.21"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -24106,7 +24106,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -24115,9 +24115,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -24132,9 +24132,9 @@
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -24149,7 +24149,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -24159,8 +24159,8 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-2.0.5.tgz",
       "integrity": "sha1-+g9Dvle2jneqTNEYBwI0kqExAn8=",
       "requires": {
-        "balanced-match": "^0.4.2",
-        "postcss": "^5.0.0"
+        "balanced-match": "0.4.2",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -24175,8 +24175,8 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-2.0.0.tgz",
       "integrity": "sha1-xzrSGj91I0vuf+4mnhVP1qhpeY0=",
       "requires": {
-        "balanced-match": "^0.2.0",
-        "postcss": "^5.0.0"
+        "balanced-match": "0.2.1",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "balanced-match": {
@@ -24191,9 +24191,9 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "requires": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-sorting": {
@@ -24202,8 +24202,8 @@
       "integrity": "sha1-MrHpr6kTuyJaatB21QPY+YO7SoI=",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.4",
-        "postcss": "^5.2.17"
+        "lodash": "4.17.10",
+        "postcss": "5.2.18"
       }
     },
     "postcss-svgo": {
@@ -24211,10 +24211,10 @@
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "requires": {
-        "is-svg": "^2.0.0",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3",
-        "svgo": "^0.7.0"
+        "is-svg": "2.1.0",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
       }
     },
     "postcss-unique-selectors": {
@@ -24222,9 +24222,9 @@
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "requires": {
-        "alphanum-sort": "^1.0.1",
-        "postcss": "^5.0.4",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-value-parser": {
@@ -24237,9 +24237,9 @@
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.4",
-        "uniqs": "^2.0.0"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "potrace": {
@@ -24247,7 +24247,7 @@
       "resolved": "https://registry.npmjs.org/potrace/-/potrace-2.1.1.tgz",
       "integrity": "sha1-eREahYGX82ZBiEX2Z/6Pf6wKeds=",
       "requires": {
-        "jimp": "^0.2.24"
+        "jimp": "0.2.28"
       }
     },
     "prebuild-install": {
@@ -24255,21 +24255,21 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
       "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
       "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
+        "detect-libc": "1.0.3",
+        "expand-template": "1.1.1",
         "github-from-package": "0.0.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
-        "rc": "^1.1.6",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "node-abi": "2.4.1",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "2.0.1",
+        "rc": "1.2.7",
+        "simple-get": "2.8.1",
+        "tar-fs": "1.16.2",
+        "tunnel-agent": "0.6.0",
+        "which-pm-runs": "1.0.0"
       },
       "dependencies": {
         "gauge": {
@@ -24277,14 +24277,14 @@
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "is-fullwidth-code-point": {
@@ -24292,7 +24292,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "npmlog": {
@@ -24300,10 +24300,10 @@
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "pump": {
@@ -24311,8 +24311,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "string-width": {
@@ -24320,9 +24320,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -24359,8 +24359,8 @@
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "requires": {
-        "renderkid": "^2.0.1",
-        "utila": "~0.4"
+        "renderkid": "2.0.1",
+        "utila": "0.4.0"
       }
     },
     "pretty-hrtime": {
@@ -24379,7 +24379,7 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.14.0.tgz",
       "integrity": "sha512-sa2s4m60bXs+kU3jcuUwx3ZCrUH7o0kuqnOOINbODqlRrDB7KY8SRx+xR/D7nHLlgfDdG7zXbRO8wJ+su5Ls0A==",
       "requires": {
-        "clipboard": "^2.0.0"
+        "clipboard": "2.0.1"
       }
     },
     "private": {
@@ -24392,12 +24392,12 @@
       "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.0.0.tgz",
       "integrity": "sha512-nm7RvWUxps+2+jZKNLkd04mNapXNariS6G5WIEVzvAqjx7EUuKcY1Dp3e6oUK7GLwzJ+3gbSbPLFAASHFQrPcQ==",
       "requires": {
-        "any-promise": "^1.3.0",
-        "deepmerge": "^2.0.1",
-        "inherits": "^2.0.3",
-        "next-tick": "^1.0.0",
-        "request": "^2.83.0",
-        "stream-parser": "~0.3.1"
+        "any-promise": "1.3.0",
+        "deepmerge": "2.1.0",
+        "inherits": "2.0.3",
+        "next-tick": "1.0.0",
+        "request": "2.85.0",
+        "stream-parser": "0.3.1"
       },
       "dependencies": {
         "any-promise": {
@@ -24427,7 +24427,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "promise-each": {
@@ -24435,7 +24435,7 @@
       "resolved": "https://registry.npmjs.org/promise-each/-/promise-each-2.2.0.tgz",
       "integrity": "sha1-M1MXTv8mlEgQN+BOAfd6oPttG2A=",
       "requires": {
-        "any-promise": "^0.1.0"
+        "any-promise": "0.1.0"
       }
     },
     "prop-types": {
@@ -24443,9 +24443,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
       "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       }
     },
     "proper-lockfile": {
@@ -24454,10 +24454,10 @@
       "integrity": "sha1-zv9d2J0+XxD7deHo52vHWAGlnDQ=",
       "optional": true,
       "requires": {
-        "err-code": "^1.0.0",
-        "extend": "^3.0.0",
-        "graceful-fs": "^4.1.2",
-        "retry": "^0.10.0"
+        "err-code": "1.1.2",
+        "extend": "3.0.1",
+        "graceful-fs": "4.1.11",
+        "retry": "0.10.1"
       }
     },
     "property-information": {
@@ -24470,7 +24470,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
       "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.6.0"
       }
     },
@@ -24489,11 +24489,11 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "parse-asn1": "5.1.1",
+        "randombytes": "2.0.6"
       }
     },
     "pug-error": {
@@ -24508,13 +24508,13 @@
       "integrity": "sha1-JxZVVbwEwjbkqisDZiRt+gIbYm4=",
       "dev": true,
       "requires": {
-        "clean-css": "^4.1.11",
-        "constantinople": "^3.0.1",
+        "clean-css": "4.1.11",
+        "constantinople": "3.1.2",
         "jstransformer": "1.0.0",
-        "pug-error": "^1.3.2",
-        "pug-walk": "^1.1.7",
-        "resolve": "^1.1.6",
-        "uglify-js": "^2.6.1"
+        "pug-error": "1.3.2",
+        "pug-walk": "1.1.7",
+        "resolve": "1.7.1",
+        "uglify-js": "2.8.29"
       }
     },
     "pug-lexer": {
@@ -24523,9 +24523,9 @@
       "integrity": "sha1-IQwYRX7y4XYCQnQMXmR715TOwng=",
       "dev": true,
       "requires": {
-        "character-parser": "^2.1.1",
-        "is-expression": "^3.0.0",
-        "pug-error": "^1.3.2"
+        "character-parser": "2.2.0",
+        "is-expression": "3.0.0",
+        "pug-error": "1.3.2"
       }
     },
     "pug-parser": {
@@ -24534,7 +24534,7 @@
       "integrity": "sha1-45Stmz/KkxI5QK/4hcBuRKt+aOQ=",
       "dev": true,
       "requires": {
-        "pug-error": "^1.3.2",
+        "pug-error": "1.3.2",
         "token-stream": "0.0.1"
       }
     },
@@ -24544,7 +24544,7 @@
       "integrity": "sha1-8VWVkiBu3G+FMQ2s9K+0igJa9Z8=",
       "dev": true,
       "requires": {
-        "pug-error": "^1.3.2"
+        "pug-error": "1.3.2"
       }
     },
     "pug-walk": {
@@ -24558,8 +24558,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "punycode": {
@@ -24587,7 +24587,7 @@
       "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-0.8.0.tgz",
       "integrity": "sha512-16wKpuFvLwciIq2YAsfmPUCnSR8GrYPsXRK5KVdcIuX0+W/MKZbBkFhl44ttRx4TWZHqRjfztoWOxdPF0Hb9JA==",
       "requires": {
-        "prop-types": "^15.6.0",
+        "prop-types": "15.6.1",
         "qr.js": "0.0.0"
       }
     },
@@ -24601,8 +24601,8 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
       }
     },
     "querystring": {
@@ -24631,9 +24631,9 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -24653,7 +24653,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "randomfill": {
@@ -24661,8 +24661,8 @@
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "range-parser": {
@@ -24694,7 +24694,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "statuses": "1.4.0"
           }
         },
         "setprototypeof": {
@@ -24714,10 +24714,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
       "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
       "requires": {
-        "deep-extend": "^0.5.1",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.5.1",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       }
     },
     "react": {
@@ -24725,11 +24725,11 @@
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
       "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
       "requires": {
-        "create-react-class": "^15.6.0",
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "create-react-class": "15.6.3",
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.1"
       }
     },
     "react-burger-menu": {
@@ -24737,10 +24737,10 @@
       "resolved": "https://registry.npmjs.org/react-burger-menu/-/react-burger-menu-2.4.4.tgz",
       "integrity": "sha512-Le68NqlcWQjz9evigGHOaxwZRuZ5b2HyAnbrUEOkBWOLaW07Fielg9rXQJDqWc9DJcsB2yhtgJTEwwKO5m8a/g==",
       "requires": {
-        "browserify-optional": "^1.0.0",
-        "classnames": "^2.1.1",
-        "eve": "~0.5.1",
-        "prop-types": "^15.6.1",
+        "browserify-optional": "1.0.1",
+        "classnames": "2.2.5",
+        "eve": "0.5.4",
+        "prop-types": "15.6.1",
         "snapsvg-cjs": "0.0.6"
       }
     },
@@ -24766,7 +24766,7 @@
         "inquirer": "3.3.0",
         "is-root": "1.0.0",
         "opn": "5.1.0",
-        "react-error-overlay": "^3.0.0",
+        "react-error-overlay": "3.0.0",
         "recursive-readdir": "2.2.1",
         "shell-quote": "1.6.1",
         "sockjs-client": "1.1.4",
@@ -24779,8 +24779,8 @@
           "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.3.tgz",
           "integrity": "sha1-pNLwYddXoDTs83xRQmCph1DysTE=",
           "requires": {
-            "address": "^1.0.1",
-            "debug": "^2.6.0"
+            "address": "1.0.3",
+            "debug": "2.6.9"
           }
         },
         "opn": {
@@ -24788,7 +24788,7 @@
           "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
           "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
           "requires": {
-            "is-wsl": "^1.1.0"
+            "is-wsl": "1.1.0"
           }
         }
       }
@@ -24803,10 +24803,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
       "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.10"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.1"
       }
     },
     "react-error-overlay": {
@@ -24819,10 +24819,10 @@
       "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.0.tgz",
       "integrity": "sha1-qBgR3yExOm1VxfBYxK66XW89l6c=",
       "requires": {
-        "deep-equal": "^1.0.1",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.5.4",
-        "react-side-effect": "^1.1.0"
+        "deep-equal": "1.0.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.1",
+        "react-side-effect": "1.1.5"
       }
     },
     "react-hot-loader": {
@@ -24830,11 +24830,11 @@
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.1.3.tgz",
       "integrity": "sha512-d7nZf78irxoGN5PY4zd6CSgZiroOhvIWzRast3qwTn4sSnBwlt08kV8WMQ9mitmxEdlCTwZt+5ClrRSjxWguMQ==",
       "requires": {
-        "global": "^4.3.0",
-        "react-deep-force-update": "^2.1.1",
-        "react-proxy": "^3.0.0-alpha.0",
-        "redbox-react": "^1.3.6",
-        "source-map": "^0.6.1"
+        "global": "4.3.2",
+        "react-deep-force-update": "2.1.1",
+        "react-proxy": "3.0.0-alpha.1",
+        "redbox-react": "1.6.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -24862,7 +24862,7 @@
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
       "integrity": "sha1-RABCa8+oDKpnJMd1VpUxUgn6Swc=",
       "requires": {
-        "lodash": "^4.6.1"
+        "lodash": "4.17.10"
       }
     },
     "react-router": {
@@ -24870,13 +24870,13 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
       "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
       "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.3.0",
-        "invariant": "^2.2.2",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.5.4",
-        "warning": "^3.0.0"
+        "history": "4.7.2",
+        "hoist-non-react-statics": "2.5.0",
+        "invariant": "2.2.4",
+        "loose-envify": "1.3.1",
+        "path-to-regexp": "1.7.0",
+        "prop-types": "15.6.1",
+        "warning": "3.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -24899,12 +24899,12 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.2.2.tgz",
       "integrity": "sha512-cHMFC1ZoLDfEaMFoKTjN7fry/oczMgRt5BKfMAkTu5zEuJvUiPp1J8d0eXSVTnBh6pxlbdqDhozunOOLtmKfPA==",
       "requires": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.2",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.5.4",
-        "react-router": "^4.2.0",
-        "warning": "^3.0.0"
+        "history": "4.7.2",
+        "invariant": "2.2.4",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.1",
+        "react-router": "4.2.0",
+        "warning": "3.0.0"
       }
     },
     "react-share": {
@@ -24912,10 +24912,10 @@
       "resolved": "https://registry.npmjs.org/react-share/-/react-share-1.19.1.tgz",
       "integrity": "sha512-qPtimGEKczQqRIiIy4K5JL+IiWk62hNIcNDFGKr28jfs1FZ4aAwLSQJonkxuzUcrJkns7HQLMRLUPCNmTo++CA==",
       "requires": {
-        "babel-runtime": "^6.6.1",
-        "classnames": "^2.2.5",
-        "jsonp": "^0.2.1",
-        "prop-types": "^15.5.8"
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.5",
+        "jsonp": "0.2.1",
+        "prop-types": "15.6.1"
       }
     },
     "react-side-effect": {
@@ -24923,8 +24923,8 @@
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",
       "integrity": "sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==",
       "requires": {
-        "exenv": "^1.2.1",
-        "shallowequal": "^1.0.1"
+        "exenv": "1.2.2",
+        "shallowequal": "1.0.2"
       }
     },
     "react-twitter-widgets": {
@@ -24932,10 +24932,10 @@
       "resolved": "https://registry.npmjs.org/react-twitter-widgets/-/react-twitter-widgets-1.7.1.tgz",
       "integrity": "sha512-bAcR/NKqRbVRJav981bHrm2+xka7NA2nQJB6Urtj9BARqP7aeGHPC0CrrC7wdYIaluOqiF8MiTtURqIJjFs2ZA==",
       "requires": {
-        "exenv": "^1.2.1",
-        "lodash": "^4.17.4",
-        "prop-types": "^15.3.0",
-        "scriptjs": "^2.5.8"
+        "exenv": "1.2.2",
+        "lodash": "4.17.10",
+        "prop-types": "15.6.1",
+        "scriptjs": "2.5.8"
       }
     },
     "read": {
@@ -24943,7 +24943,7 @@
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.7"
       }
     },
     "read-all-stream": {
@@ -24951,8 +24951,8 @@
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "requires": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.3.6"
       }
     },
     "read-cache": {
@@ -24960,7 +24960,7 @@
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "requires": {
-        "pify": "^2.3.0"
+        "pify": "2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -24981,7 +24981,7 @@
       "integrity": "sha1-JezP86FTtoCa+ssj7hU4fbng7mE=",
       "dev": true,
       "requires": {
-        "gather-stream": "^1.0.0"
+        "gather-stream": "1.0.0"
       }
     },
     "read-pkg": {
@@ -24989,9 +24989,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
@@ -24999,8 +24999,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -25008,7 +25008,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -25018,13 +25018,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdir-enhanced": {
@@ -25032,9 +25032,9 @@
       "resolved": "https://registry.npmjs.org/readdir-enhanced/-/readdir-enhanced-1.5.2.tgz",
       "integrity": "sha1-YUYwSGkKxqRVt1ti+nioj43IXlM=",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "es6-promise": "^4.1.0",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "es6-promise": "4.2.4",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "readdirp": {
@@ -25042,10 +25042,10 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       },
       "dependencies": {
         "minimatch": {
@@ -25053,7 +25053,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -25064,8 +25064,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
         "mute-stream": "0.0.5"
       },
       "dependencies": {
@@ -25075,7 +25075,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "mute-stream": {
@@ -25093,9 +25093,9 @@
       "dev": true,
       "requires": {
         "ast-types": "0.8.12",
-        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "private": "0.1.8",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "ast-types": {
@@ -25117,7 +25117,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.7.1"
       }
     },
     "recursive-readdir": {
@@ -25133,7 +25133,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -25143,10 +25143,10 @@
       "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.6.0.tgz",
       "integrity": "sha512-mLjM5eYR41yOp5YKHpd3syFeGq6B4Wj5vZr64nbLvTZW5ZLff4LYk7VE4ITpVxkZpCY6OZuqh0HiP3A3uEaCpg==",
       "requires": {
-        "error-stack-parser": "^1.3.6",
-        "object-assign": "^4.0.1",
-        "prop-types": "^15.5.4",
-        "sourcemapped-stacktrace": "^1.1.6"
+        "error-stack-parser": "1.3.6",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.1",
+        "sourcemapped-stacktrace": "1.1.8"
       },
       "dependencies": {
         "error-stack-parser": {
@@ -25154,7 +25154,7 @@
           "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
           "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
           "requires": {
-            "stackframe": "^0.3.1"
+            "stackframe": "0.3.1"
           }
         },
         "stackframe": {
@@ -25169,8 +25169,8 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "reduce-css-calc": {
@@ -25178,9 +25178,9 @@
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "requires": {
-        "balanced-match": "^0.4.2",
-        "math-expression-evaluator": "^1.2.14",
-        "reduce-function-call": "^1.0.1"
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -25195,7 +25195,7 @@
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "requires": {
-        "balanced-match": "^0.4.2"
+        "balanced-match": "0.4.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -25210,10 +25210,10 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "lodash": "4.17.10",
+        "lodash-es": "4.17.10",
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.2.0"
       }
     },
     "redux-devtools-instrument": {
@@ -25221,8 +25221,8 @@
       "resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.8.3.tgz",
       "integrity": "sha1-xRDWerTl5FJazW5BDCWrRrhaynw=",
       "requires": {
-        "lodash": "^4.2.0",
-        "symbol-observable": "^1.0.2"
+        "lodash": "4.17.10",
+        "symbol-observable": "1.2.0"
       }
     },
     "regenerate": {
@@ -25236,12 +25236,12 @@
       "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
       "dev": true,
       "requires": {
-        "commoner": "~0.10.3",
-        "defs": "~1.1.0",
-        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
-        "private": "~0.1.5",
+        "commoner": "0.10.8",
+        "defs": "1.1.1",
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "private": "0.1.8",
         "recast": "0.10.33",
-        "through": "~2.3.8"
+        "through": "2.3.8"
       },
       "dependencies": {
         "esprima-fb": {
@@ -25262,9 +25262,9 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -25272,7 +25272,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -25280,8 +25280,8 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpu": {
@@ -25290,11 +25290,11 @@
       "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
       "dev": true,
       "requires": {
-        "esprima": "^2.6.0",
-        "recast": "^0.10.10",
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "esprima": "2.7.3",
+        "recast": "0.10.33",
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "regexpu-core": {
@@ -25302,9 +25302,9 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "registry-auth-token": {
@@ -25312,8 +25312,8 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.7",
+        "safe-buffer": "5.1.2"
       }
     },
     "registry-url": {
@@ -25321,7 +25321,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.7"
       }
     },
     "regjsgen": {
@@ -25334,7 +25334,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -25344,27 +25344,52 @@
         }
       }
     },
+    "rehype-react": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-3.0.2.tgz",
+      "integrity": "sha512-TtqEF4Yh57mt+SUuD2DVOPf7tRlLgSvQRo9dq+iChn/CZ7bDE9gL3mqvK8FXMuTfFso6DUW1Cy87YchIwLsMUQ==",
+      "requires": {
+        "has": "1.0.1",
+        "hast-to-hyperscript": "4.0.0"
+      },
+      "dependencies": {
+        "hast-to-hyperscript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-4.0.0.tgz",
+          "integrity": "sha512-4kOn4ihjDJTQg7B53ZcZ6NyExtTeG3hLNZv6rSKhq4haQvD52zCllE+49iLiC1VWuc4DbHmt96FHPGlHbslZqQ==",
+          "requires": {
+            "comma-separated-tokens": "1.0.5",
+            "is-nan": "1.2.1",
+            "kebab-case": "1.0.0",
+            "property-information": "3.2.0",
+            "space-separated-tokens": "1.1.2",
+            "trim": "0.0.1",
+            "unist-util-is": "2.1.2"
+          }
+        }
+      }
+    },
     "relay-compiler": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-1.4.1.tgz",
       "integrity": "sha512-8O9dVIOOTp1TlbQhdNp2EBO/WUaSEPaYhQ8HFgMVjpvLTCaCfHEpptNQPJf5uDG/AH1p2qhPtLaCyQ2pBYh7Cw==",
       "requires": {
-        "babel-generator": "^6.24.1",
-        "babel-polyfill": "^6.20.0",
-        "babel-preset-fbjs": "^2.1.4",
-        "babel-runtime": "^6.23.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.24.1",
-        "babylon": "^6.18.0",
-        "chalk": "^1.1.1",
-        "fast-glob": "^1.0.1",
-        "fb-watchman": "^2.0.0",
-        "fbjs": "^0.8.14",
-        "graphql": "^0.11.3",
-        "immutable": "~3.7.6",
+        "babel-generator": "6.26.1",
+        "babel-polyfill": "6.26.0",
+        "babel-preset-fbjs": "2.1.4",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "chalk": "1.1.3",
+        "fast-glob": "1.0.1",
+        "fb-watchman": "2.0.0",
+        "fbjs": "0.8.16",
+        "graphql": "0.11.7",
+        "immutable": "3.7.6",
         "relay-runtime": "1.4.1",
-        "signedsource": "^1.0.0",
-        "yargs": "^9.0.0"
+        "signedsource": "1.0.0",
+        "yargs": "9.0.1"
       },
       "dependencies": {
         "cliui": {
@@ -25372,9 +25397,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "string-width": {
@@ -25382,9 +25407,9 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -25394,7 +25419,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "yargs": {
@@ -25402,19 +25427,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
           "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
           "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
           }
         },
         "yargs-parser": {
@@ -25422,7 +25447,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -25437,8 +25462,8 @@
       "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-1.4.1.tgz",
       "integrity": "sha512-hsEVCPik0Wo+8xvVqaMK96d45fqYAcHz/UCAw2qy1dxY+2kHUhnDUh6CGilFKB1H3f+DLzvqIHUyNYKWS/jZ/g==",
       "requires": {
-        "babel-runtime": "^6.23.0",
-        "fbjs": "^0.8.14",
+        "babel-runtime": "6.26.0",
+        "fbjs": "0.8.16",
         "relay-debugger-react-native-runtime": "0.0.10"
       }
     },
@@ -25447,9 +25472,9 @@
       "resolved": "https://registry.npmjs.org/remark/-/remark-7.0.1.tgz",
       "integrity": "sha1-pd5NrPq/D2CkmCbvJMR5gH+QS/s=",
       "requires": {
-        "remark-parse": "^3.0.0",
-        "remark-stringify": "^3.0.0",
-        "unified": "^6.0.0"
+        "remark-parse": "3.0.1",
+        "remark-stringify": "3.0.1",
+        "unified": "6.2.0"
       },
       "dependencies": {
         "remark-parse": {
@@ -25457,22 +25482,22 @@
           "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-3.0.1.tgz",
           "integrity": "sha1-G5+EGkTY9PvyJGhQJlRZpOs1TIA=",
           "requires": {
-            "collapse-white-space": "^1.0.2",
-            "has": "^1.0.1",
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "is-word-character": "^1.0.0",
-            "markdown-escapes": "^1.0.0",
-            "parse-entities": "^1.0.2",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
+            "collapse-white-space": "1.0.4",
+            "has": "1.0.1",
+            "is-alphabetical": "1.0.2",
+            "is-decimal": "1.0.2",
+            "is-whitespace-character": "1.0.2",
+            "is-word-character": "1.0.2",
+            "markdown-escapes": "1.0.2",
+            "parse-entities": "1.1.2",
+            "repeat-string": "1.6.1",
+            "state-toggle": "1.0.1",
             "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^1.0.0",
-            "vfile-location": "^2.0.0",
-            "xtend": "^4.0.1"
+            "trim-trailing-lines": "1.1.1",
+            "unherit": "1.1.1",
+            "unist-util-remove-position": "1.1.2",
+            "vfile-location": "2.0.3",
+            "xtend": "4.0.1"
           }
         },
         "remark-stringify": {
@@ -25480,20 +25505,20 @@
           "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-3.0.1.tgz",
           "integrity": "sha1-eSQr6+CnUggbWAlRb6DAbt7Aac8=",
           "requires": {
-            "ccount": "^1.0.0",
-            "is-alphanumeric": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "longest-streak": "^2.0.1",
-            "markdown-escapes": "^1.0.0",
-            "markdown-table": "^1.1.0",
-            "mdast-util-compact": "^1.0.0",
-            "parse-entities": "^1.0.2",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "stringify-entities": "^1.0.1",
-            "unherit": "^1.0.4",
-            "xtend": "^4.0.1"
+            "ccount": "1.0.3",
+            "is-alphanumeric": "1.0.0",
+            "is-decimal": "1.0.2",
+            "is-whitespace-character": "1.0.2",
+            "longest-streak": "2.0.2",
+            "markdown-escapes": "1.0.2",
+            "markdown-table": "1.1.2",
+            "mdast-util-compact": "1.0.1",
+            "parse-entities": "1.1.2",
+            "repeat-string": "1.6.1",
+            "state-toggle": "1.0.1",
+            "stringify-entities": "1.3.2",
+            "unherit": "1.1.1",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -25504,9 +25529,9 @@
       "integrity": "sha512-q5GMjGypUS4rTZb3WfMQcGpClSC38A9Ogg1h/HB2GLsqypDetmAfy0X+tuJ6JeyCPVOXXCDgsDCQq4QPqKmxBA==",
       "dev": true,
       "requires": {
-        "markdown-extensions": "^1.1.0",
-        "remark": "^8.0.0",
-        "unified-args": "^4.0.0"
+        "markdown-extensions": "1.1.1",
+        "remark": "8.0.0",
+        "unified-args": "4.0.0"
       },
       "dependencies": {
         "remark": {
@@ -25515,9 +25540,9 @@
           "integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
           "dev": true,
           "requires": {
-            "remark-parse": "^4.0.0",
-            "remark-stringify": "^4.0.0",
-            "unified": "^6.0.0"
+            "remark-parse": "4.0.0",
+            "remark-stringify": "4.0.0",
+            "unified": "6.2.0"
           }
         }
       }
@@ -25528,7 +25553,7 @@
       "integrity": "sha512-wvTTuB5O5pF8SxqahQjjrU3dtuhygYjaGcOZTw+4ACgSE4RBINDlNqN46HjcV3X0ib5GmObJUt5a2mmhtmuTqw==",
       "dev": true,
       "requires": {
-        "remark-message-control": "^4.0.0"
+        "remark-message-control": "4.1.0"
       }
     },
     "remark-lint-final-newline": {
@@ -25537,7 +25562,7 @@
       "integrity": "sha512-neztZuEBw2ka9N35Ap0ZfBqPPA/TNSksGQNq0G9VWL370+s+6k+GUEaq7cjcQACYt310oWl4bx5ukbmo/7L5WA==",
       "dev": true,
       "requires": {
-        "unified-lint-rule": "^1.0.0"
+        "unified-lint-rule": "1.0.2"
       }
     },
     "remark-lint-hard-break-spaces": {
@@ -25546,10 +25571,10 @@
       "integrity": "sha512-uh7LqHgRPCphiCvRzBVA4D0Ml2IqPaw89lWJdQ6HvYiV8ChB/OFLBapHi6OKW7NVVVPPJsElPMB/UPUsKFaPTg==",
       "dev": true,
       "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-list-item-bullet-indent": {
@@ -25558,11 +25583,11 @@
       "integrity": "sha512-Qvh+43zMlm8kSurWzswHdNS+7bkz2v0t8yUcrD9yQ0USkd1W/MgV4PpPtNvMdL8YzVZuyNyNs6cOf96aPg75hQ==",
       "dev": true,
       "requires": {
-        "plur": "^2.1.2",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "plur": "2.1.2",
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-list-item-indent": {
@@ -25571,11 +25596,11 @@
       "integrity": "sha512-dSUFGQYtduuaos+5oXH89RTk0rGUe6DFf04q+rxQ7Z3YRbuXhAU2nYeY0/HENYiWJU1xFLteZkDvKMj0NfS3DQ==",
       "dev": true,
       "requires": {
-        "plur": "^2.1.2",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "plur": "2.1.2",
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-no-auto-link-without-protocol": {
@@ -25584,11 +25609,11 @@
       "integrity": "sha512-MHl0hNtF8Rc0lg6iuVP7/0rnp4uZadm3S07/1TiFeqzU22KFxxzcC8980Q4+I8oPZE0d1x80h9DmkNAVFwhDjQ==",
       "dev": true,
       "requires": {
-        "mdast-util-to-string": "^1.0.2",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "mdast-util-to-string": "1.0.4",
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-no-blockquote-without-marker": {
@@ -25597,11 +25622,11 @@
       "integrity": "sha512-8VTQ/MP3flvG4U0tFSD+DMVT7F/4u9SnQLb/jjeRC3DzgbsIagIUqpWYAKkc+yBz9S/lgftA92lLP5PrlOa5DA==",
       "dev": true,
       "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1",
-        "vfile-location": "^2.0.1"
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.3.1",
+        "vfile-location": "2.0.3"
       }
     },
     "remark-lint-no-duplicate-definitions": {
@@ -25610,10 +25635,10 @@
       "integrity": "sha512-3I0V3UVJ0gkDKZahSZ0xdFmklecr5SMwXcWbVBzXvHR59LqgjMVHFI7G/QZ6k2imOl1X22YVRz+mpMjacu2Ipw==",
       "dev": true,
       "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-no-heading-content-indent": {
@@ -25622,12 +25647,12 @@
       "integrity": "sha512-VHOqVx3Qb9tckHu/DkpQjBqlXQHcfabKaSuiXdeH+G0sfgWOxL0KCmA6fsUqUdj7xJ8Q7YpH/c3wb3nZ/85d+Q==",
       "dev": true,
       "requires": {
-        "mdast-util-heading-style": "^1.0.2",
-        "plur": "^2.1.2",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "mdast-util-heading-style": "1.0.3",
+        "plur": "2.1.2",
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-no-inline-padding": {
@@ -25636,10 +25661,10 @@
       "integrity": "sha512-nRl6vA45ZPdMz3/rVMZw7WRRqLFuMrzhdkrbrGLjwBovdIeD/IGCEbDA5NR60g2xT9V5dAmKogvHEH1bIr8SdQ==",
       "dev": true,
       "requires": {
-        "mdast-util-to-string": "^1.0.2",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^1.1.1"
+        "mdast-util-to-string": "1.0.4",
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-no-literal-urls": {
@@ -25648,11 +25673,11 @@
       "integrity": "sha512-YMsZFVYQDt9gvpc6THL76GzyhCR+cK79vjyEOEmX+O3tOjxQstbi0oW6Lngbl1WbpkCW5TWEzSKOorQowYI2wg==",
       "dev": true,
       "requires": {
-        "mdast-util-to-string": "^1.0.2",
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "mdast-util-to-string": "1.0.4",
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-no-shortcut-reference-image": {
@@ -25661,9 +25686,9 @@
       "integrity": "sha512-nUQ+4xB5hKZTCl9gvg7c+W1T3ddsnjgu4zwRza2Bn+21cKmUzx+z9dvlZ4aVuNGmxuWHbKI8/ZkKuB8Eu27vJw==",
       "dev": true,
       "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^1.1.1"
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-no-shortcut-reference-link": {
@@ -25672,9 +25697,9 @@
       "integrity": "sha512-A6ZexZ6XyQ7fXebrj5WgW5FkSJ81GobjWyMFVmBxgxPd9GH2BkRsZ10aFSkQQvfKSrqbnOL2vrigGMgbiERRxA==",
       "dev": true,
       "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^1.1.1"
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-no-undefined-references": {
@@ -25683,9 +25708,9 @@
       "integrity": "sha512-wKYax0htxL3/QhspNxWY9xcJb+fTiPYKzra8ye6NtTj2mH06mW0UMmQ5G36OeRBfQd/VHUQKkpKVZfkL3hOtMA==",
       "dev": true,
       "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^1.1.1"
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-no-unused-definitions": {
@@ -25694,9 +25719,9 @@
       "integrity": "sha512-weNwWXvoSBmB3L2Yh8oxY0ylF6L5b/PjFbOhzBU4SlnpFOMfTn3rwNxOxbTrDS8MG2JTPVTaFn4ajXr/zkbH0Q==",
       "dev": true,
       "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^1.1.1"
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-lint-ordered-list-marker-style": {
@@ -25705,10 +25730,10 @@
       "integrity": "sha512-LJICUZIxqHHi360EP90zbDP+2QQIVVgPGlz0AatuR9ifd7xqAzraQKxsQajAZpuOepZgjBMTOz9L9W0Znx7ujA==",
       "dev": true,
       "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^1.1.1"
+        "unified-lint-rule": "1.0.2",
+        "unist-util-generated": "1.1.2",
+        "unist-util-position": "3.0.1",
+        "unist-util-visit": "1.3.1"
       }
     },
     "remark-message-control": {
@@ -25717,9 +25742,9 @@
       "integrity": "sha512-e1dszks4YKY7hLAkhS2367jBjBpAfvi+kVgSN/tOFrdp3qxITjiNR5fOFnyYF8vvorkQ9uxlKJoZUOW8T7rKDg==",
       "dev": true,
       "requires": {
-        "mdast-comment-marker": "^1.0.0",
-        "unified-message-control": "^1.0.0",
-        "xtend": "^4.0.1"
+        "mdast-comment-marker": "1.0.2",
+        "unified-message-control": "1.0.4",
+        "xtend": "4.0.1"
       }
     },
     "remark-parse": {
@@ -25727,21 +25752,21 @@
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
       "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
       "requires": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
+        "collapse-white-space": "1.0.4",
+        "is-alphabetical": "1.0.2",
+        "is-decimal": "1.0.2",
+        "is-whitespace-character": "1.0.2",
+        "is-word-character": "1.0.2",
+        "markdown-escapes": "1.0.2",
+        "parse-entities": "1.1.2",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.1",
         "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
+        "trim-trailing-lines": "1.1.1",
+        "unherit": "1.1.1",
+        "unist-util-remove-position": "1.1.2",
+        "vfile-location": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "remark-preset-lint-recommended": {
@@ -25750,22 +25775,22 @@
       "integrity": "sha512-C/rR0Nz4LC5dhUTO8Zknrml4VuhcNbk4wta3NHd5dKrouH0OMmwJIyV1xWHK8KvRZIYJ1qdrUIM7+isYPGUl7w==",
       "dev": true,
       "requires": {
-        "remark-lint": "^6.0.0",
-        "remark-lint-final-newline": "^1.0.0",
-        "remark-lint-hard-break-spaces": "^1.0.0",
-        "remark-lint-list-item-bullet-indent": "^1.0.0",
-        "remark-lint-list-item-indent": "^1.0.0",
-        "remark-lint-no-auto-link-without-protocol": "^1.0.0",
-        "remark-lint-no-blockquote-without-marker": "^2.0.0",
-        "remark-lint-no-duplicate-definitions": "^1.0.0",
-        "remark-lint-no-heading-content-indent": "^1.0.0",
-        "remark-lint-no-inline-padding": "^1.0.0",
-        "remark-lint-no-literal-urls": "^1.0.0",
-        "remark-lint-no-shortcut-reference-image": "^1.0.0",
-        "remark-lint-no-shortcut-reference-link": "^1.0.0",
-        "remark-lint-no-undefined-references": "^1.0.0",
-        "remark-lint-no-unused-definitions": "^1.0.0",
-        "remark-lint-ordered-list-marker-style": "^1.0.0"
+        "remark-lint": "6.0.1",
+        "remark-lint-final-newline": "1.0.1",
+        "remark-lint-hard-break-spaces": "1.0.2",
+        "remark-lint-list-item-bullet-indent": "1.0.1",
+        "remark-lint-list-item-indent": "1.0.1",
+        "remark-lint-no-auto-link-without-protocol": "1.0.1",
+        "remark-lint-no-blockquote-without-marker": "2.0.1",
+        "remark-lint-no-duplicate-definitions": "1.0.1",
+        "remark-lint-no-heading-content-indent": "1.0.1",
+        "remark-lint-no-inline-padding": "1.0.1",
+        "remark-lint-no-literal-urls": "1.0.1",
+        "remark-lint-no-shortcut-reference-image": "1.0.1",
+        "remark-lint-no-shortcut-reference-link": "1.0.2",
+        "remark-lint-no-undefined-references": "1.0.1",
+        "remark-lint-no-unused-definitions": "1.0.1",
+        "remark-lint-ordered-list-marker-style": "1.0.1"
       }
     },
     "remark-retext": {
@@ -25773,7 +25798,7 @@
       "resolved": "https://registry.npmjs.org/remark-retext/-/remark-retext-3.1.0.tgz",
       "integrity": "sha1-Gz3y1JRpwNNZbK2G6RUDqLYA/cw=",
       "requires": {
-        "mdast-util-to-nlcst": "^3.2.0"
+        "mdast-util-to-nlcst": "3.2.0"
       }
     },
     "remark-stringify": {
@@ -25781,20 +25806,20 @@
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz",
       "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
       "requires": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^1.1.0",
-        "mdast-util-compact": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
+        "ccount": "1.0.3",
+        "is-alphanumeric": "1.0.0",
+        "is-decimal": "1.0.2",
+        "is-whitespace-character": "1.0.2",
+        "longest-streak": "2.0.2",
+        "markdown-escapes": "1.0.2",
+        "markdown-table": "1.1.2",
+        "mdast-util-compact": "1.0.1",
+        "parse-entities": "1.1.2",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.1",
+        "stringify-entities": "1.3.2",
+        "unherit": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "remote-redux-devtools": {
@@ -25802,12 +25827,12 @@
       "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.12.tgz",
       "integrity": "sha1-QsuV36nlTB2WcTF8Xnu6QeaMrsI=",
       "requires": {
-        "jsan": "^3.1.5",
-        "querystring": "^0.2.0",
-        "redux-devtools-instrument": "^1.3.3",
-        "remotedev-utils": "^0.1.1",
-        "rn-host-detect": "^1.0.1",
-        "socketcluster-client": "^5.3.1"
+        "jsan": "3.1.10",
+        "querystring": "0.2.0",
+        "redux-devtools-instrument": "1.8.3",
+        "remotedev-utils": "0.1.4",
+        "rn-host-detect": "1.1.3",
+        "socketcluster-client": "5.5.2"
       }
     },
     "remotedev-serialize": {
@@ -25815,7 +25840,7 @@
       "resolved": "https://registry.npmjs.org/remotedev-serialize/-/remotedev-serialize-0.1.1.tgz",
       "integrity": "sha1-D1mAALfddRXWf5tRph0hHhjOlVQ=",
       "requires": {
-        "jsan": "^3.1.9"
+        "jsan": "3.1.10"
       }
     },
     "remotedev-utils": {
@@ -25823,11 +25848,11 @@
       "resolved": "https://registry.npmjs.org/remotedev-utils/-/remotedev-utils-0.1.4.tgz",
       "integrity": "sha1-ZDcAgZqUNngHPHXrGF6B2WYgs0g=",
       "requires": {
-        "get-params": "^0.1.2",
-        "jsan": "^3.1.5",
-        "lodash": "^4.0.0",
-        "remotedev-serialize": "^0.1.0",
-        "shortid": "^2.2.6"
+        "get-params": "0.1.2",
+        "jsan": "3.1.10",
+        "lodash": "4.17.10",
+        "remotedev-serialize": "0.1.1",
+        "shortid": "2.2.8"
       }
     },
     "remove-trailing-separator": {
@@ -25840,11 +25865,11 @@
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "requires": {
-        "css-select": "^1.1.0",
-        "dom-converter": "~0.1",
-        "htmlparser2": "~3.3.0",
-        "strip-ansi": "^3.0.0",
-        "utila": "~0.3"
+        "css-select": "1.2.0",
+        "dom-converter": "0.1.4",
+        "htmlparser2": "3.3.0",
+        "strip-ansi": "3.0.1",
+        "utila": "0.3.3"
       },
       "dependencies": {
         "utila": {
@@ -25869,7 +25894,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -25882,28 +25907,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       }
     },
     "require-directory": {
@@ -25939,8 +25964,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       },
       "dependencies": {
         "resolve-from": {
@@ -25962,7 +25987,7 @@
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
       "requires": {
-        "underscore": "~1.6.0"
+        "underscore": "1.6.0"
       },
       "dependencies": {
         "underscore": {
@@ -25978,7 +26003,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-cwd": {
@@ -25986,7 +26011,7 @@
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-dir": {
@@ -25994,8 +26019,8 @@
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       },
       "dependencies": {
         "expand-tilde": {
@@ -26003,7 +26028,7 @@
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.1"
           }
         }
       }
@@ -26028,8 +26053,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -26042,8 +26067,8 @@
       "resolved": "https://registry.npmjs.org/retext-english/-/retext-english-3.0.0.tgz",
       "integrity": "sha1-wXy1a9Xxuj3uM1XdurefHEiUqAk=",
       "requires": {
-        "parse-english": "^4.0.0",
-        "unherit": "^1.0.4"
+        "parse-english": "4.1.1",
+        "unherit": "1.1.1"
       }
     },
     "retry": {
@@ -26072,7 +26097,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -26080,7 +26105,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "ripemd160": {
@@ -26088,8 +26113,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "rn-host-detect": {
@@ -26104,7 +26129,7 @@
       "optional": true,
       "requires": {
         "@types/estree": "0.0.38",
-        "@types/node": "*"
+        "@types/node": "7.0.64"
       }
     },
     "rss": {
@@ -26126,7 +26151,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
           "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
           "requires": {
-            "mime-db": "~1.25.0"
+            "mime-db": "1.25.0"
           }
         }
       }
@@ -26141,7 +26166,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "rx-lite": {
@@ -26154,7 +26179,7 @@
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "requires": {
-        "rx-lite": "*"
+        "rx-lite": "4.0.8"
       }
     },
     "safe-buffer": {
@@ -26167,7 +26192,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "sane": {
@@ -26176,13 +26201,13 @@
       "integrity": "sha1-s1ebzLRclM8gNVzIESSZDf00bjA=",
       "optional": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "exec-sh": "^0.2.0",
-        "fb-watchman": "^2.0.0",
-        "minimatch": "^3.0.2",
-        "minimist": "^1.1.1",
-        "walker": "~1.0.5",
-        "watch": "~0.10.0"
+        "anymatch": "1.3.2",
+        "exec-sh": "0.2.1",
+        "fb-watchman": "2.0.0",
+        "minimatch": "3.0.4",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.10.0"
       },
       "dependencies": {
         "minimatch": {
@@ -26191,7 +26216,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "optional": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -26201,16 +26226,16 @@
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.18.2.tgz",
       "integrity": "sha512-52ThA+Z7h6BnvpSVbURwChl10XZrps5q7ytjTwWcIe9bmJwnVP6cpEVK2NvDOUhGupoqAvNbUz3cpnJDp4+/pg==",
       "requires": {
-        "chalk": "^2.3.0",
-        "htmlparser2": "^3.9.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.mergewith": "^4.6.0",
-        "postcss": "^6.0.14",
-        "srcset": "^1.0.0",
-        "xtend": "^4.0.0"
+        "chalk": "2.4.1",
+        "htmlparser2": "3.9.2",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.escaperegexp": "4.1.2",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.mergewith": "4.6.1",
+        "postcss": "6.0.22",
+        "srcset": "1.0.0",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -26218,7 +26243,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -26226,9 +26251,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "domhandler": {
@@ -26236,7 +26261,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
           "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "has-flag": {
@@ -26249,12 +26274,12 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.2",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
         "postcss": {
@@ -26262,9 +26287,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -26277,7 +26302,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -26292,7 +26317,7 @@
       "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.0.6.tgz",
       "integrity": "sha1-s4vUepk+eCkPvFNGeGf2sqCghjk=",
       "requires": {
-        "sc-emitter": "1.x.x"
+        "sc-emitter": "1.1.0"
       }
     },
     "sc-emitter": {
@@ -26325,7 +26350,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "requires": {
-        "ajv": "^5.0.0"
+        "ajv": "5.5.2"
       }
     },
     "scriptjs": {
@@ -26338,8 +26363,8 @@
       "resolved": "https://registry.npmjs.org/scroll-behavior/-/scroll-behavior-0.9.9.tgz",
       "integrity": "sha1-6/4GWEVbgq2IW2YZUhVBZnTazOI=",
       "requires": {
-        "dom-helpers": "^3.2.1",
-        "invariant": "^2.2.2"
+        "dom-helpers": "3.3.1",
+        "invariant": "2.2.4"
       }
     },
     "seek-bzip": {
@@ -26347,7 +26372,7 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "requires": {
-        "commander": "~2.8.1"
+        "commander": "2.8.1"
       },
       "dependencies": {
         "commander": {
@@ -26355,7 +26380,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         }
       }
@@ -26376,7 +26401,7 @@
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.0"
       }
     },
     "semver-regex": {
@@ -26389,7 +26414,7 @@
       "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
       "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.5.0"
       }
     },
     "send": {
@@ -26398,18 +26423,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "mime": {
@@ -26459,7 +26484,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -26467,9 +26492,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
           "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "filesize": {
@@ -26482,9 +26507,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
           "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
           }
         },
         "has-flag": {
@@ -26497,7 +26522,7 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "supports-color": {
@@ -26505,7 +26530,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -26515,13 +26540,13 @@
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.18",
+        "parseurl": "1.3.2"
       }
     },
     "serve-static": {
@@ -26529,9 +26554,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -26555,10 +26580,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -26566,7 +26591,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -26586,8 +26611,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "shallow-compare": {
@@ -26605,16 +26630,16 @@
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.20.2.tgz",
       "integrity": "sha512-cFL2qUT9eyR29bI+gj5kQjWlj+VIuTGdcY/CErQqmwJ4FKTXhmdE6d/zwjmrAokzr5n547KQed8HFQsmyUv9uw==",
       "requires": {
-        "color": "^3.0.0",
-        "detect-libc": "^1.0.3",
-        "fs-copy-file-sync": "^1.0.1",
-        "nan": "^2.10.0",
-        "npmlog": "^4.1.2",
-        "prebuild-install": "^2.5.3",
-        "semver": "^5.5.0",
-        "simple-get": "^2.8.1",
-        "tar": "^4.4.1",
-        "tunnel-agent": "^0.6.0"
+        "color": "3.0.0",
+        "detect-libc": "1.0.3",
+        "fs-copy-file-sync": "1.1.1",
+        "nan": "2.10.0",
+        "npmlog": "4.1.2",
+        "prebuild-install": "2.5.3",
+        "semver": "5.5.0",
+        "simple-get": "2.8.1",
+        "tar": "4.4.2",
+        "tunnel-agent": "0.6.0"
       },
       "dependencies": {
         "color": {
@@ -26622,8 +26647,8 @@
           "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
           "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
           "requires": {
-            "color-convert": "^1.9.1",
-            "color-string": "^1.5.2"
+            "color-convert": "1.9.1",
+            "color-string": "1.5.2"
           }
         },
         "color-string": {
@@ -26631,8 +26656,8 @@
           "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
           "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
           "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
+            "color-name": "1.1.3",
+            "simple-swizzle": "0.2.2"
           }
         },
         "gauge": {
@@ -26640,14 +26665,14 @@
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "is-fullwidth-code-point": {
@@ -26655,7 +26680,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "npmlog": {
@@ -26663,10 +26688,10 @@
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "string-width": {
@@ -26674,9 +26699,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -26686,7 +26711,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -26699,10 +26724,10 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
       }
     },
     "shelljs": {
@@ -26710,9 +26735,9 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.0.tgz",
       "integrity": "sha1-P28uSWXOxWX2X/OGHWRPh5KBpXY=",
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
       },
       "dependencies": {
         "interpret": {
@@ -26770,9 +26795,9 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "requires": {
-        "decompress-response": "^3.3.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
       }
     },
     "simple-is": {
@@ -26786,7 +26811,7 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
-        "is-arrayish": "^0.3.1"
+        "is-arrayish": "0.3.1"
       },
       "dependencies": {
         "is-arrayish": {
@@ -26801,8 +26826,8 @@
       "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-1.13.0.tgz",
       "integrity": "sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=",
       "requires": {
-        "underscore": "^1.7.0",
-        "url-join": "^1.1.0"
+        "underscore": "1.9.0",
+        "url-join": "1.1.0"
       }
     },
     "slash": {
@@ -26827,14 +26852,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -26842,7 +26867,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -26850,7 +26875,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -26860,9 +26885,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -26870,7 +26895,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -26878,7 +26903,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -26886,7 +26911,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -26894,9 +26919,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -26916,7 +26941,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "snapsvg": {
@@ -26924,7 +26949,7 @@
       "resolved": "https://registry.npmjs.org/snapsvg/-/snapsvg-0.5.1.tgz",
       "integrity": "sha1-DK9Sx5GJopB0b8RGzF6GP2vd3+M=",
       "requires": {
-        "eve": "~0.5.1"
+        "eve": "0.5.4"
       }
     },
     "snapsvg-cjs": {
@@ -26940,7 +26965,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "socket.io": {
@@ -26948,12 +26973,12 @@
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.0.tgz",
       "integrity": "sha512-KS+3CNWWNtLbVN5j0/B+1hjxRzey+oTK6ejpAOoxMZis6aXeB8cUtfuvjHl97tuZx+t/qD/VyqFMjuzu2Js6uQ==",
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "3.1.0",
+        "engine.io": "3.2.0",
+        "has-binary2": "1.0.2",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.1.0",
-        "socket.io-parser": "~3.2.0"
+        "socket.io-parser": "3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -26980,15 +27005,15 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.2.0",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "engine.io-client": "3.2.1",
+        "has-binary2": "1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.2.0",
+        "socket.io-parser": "3.2.0",
         "to-array": "0.1.4"
       },
       "dependencies": {
@@ -27008,7 +27033,7 @@
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
+        "debug": "3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -27036,10 +27061,10 @@
         "clone": "2.1.1",
         "linked-list": "0.1.0",
         "querystring": "0.2.0",
-        "sc-channel": "~1.0.6",
-        "sc-emitter": "~1.1.0",
-        "sc-errors": "~1.3.0",
-        "sc-formatter": "~3.0.0",
+        "sc-channel": "1.0.6",
+        "sc-emitter": "1.1.0",
+        "sc-errors": "1.3.3",
+        "sc-formatter": "3.0.2",
         "ws": "3.0.0"
       },
       "dependencies": {
@@ -27055,8 +27080,8 @@
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "requires": {
-        "faye-websocket": "^0.10.0",
-        "uuid": "^3.0.1"
+        "faye-websocket": "0.10.0",
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "faye-websocket": {
@@ -27064,7 +27089,7 @@
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "websocket-driver": "0.7.0"
           }
         }
       }
@@ -27074,12 +27099,12 @@
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
       "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
       "requires": {
-        "debug": "^2.6.6",
+        "debug": "2.6.9",
         "eventsource": "0.1.6",
-        "faye-websocket": "~0.11.0",
-        "inherits": "^2.0.1",
-        "json3": "^3.3.2",
-        "url-parse": "^1.1.8"
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.4.0"
       }
     },
     "sort-keys": {
@@ -27087,7 +27112,7 @@
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "source-list-map": {
@@ -27105,11 +27130,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.1",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -27117,7 +27142,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "source-map-url": {
@@ -27158,8 +27183,8 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -27172,8 +27197,8 @@
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -27192,7 +27217,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "split2": {
@@ -27201,7 +27226,7 @@
       "integrity": "sha1-At2smtwD7Au3jBKC7Aecpuha6QA=",
       "dev": true,
       "requires": {
-        "through2": "~0.6.1"
+        "through2": "0.6.5"
       },
       "dependencies": {
         "isarray": {
@@ -27216,10 +27241,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -27234,8 +27259,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -27250,9 +27275,9 @@
       "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
       "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
       "requires": {
-        "chalk": "^1.0.0",
-        "console-stream": "^0.1.1",
-        "lpad-align": "^1.0.1"
+        "chalk": "1.1.3",
+        "console-stream": "0.1.1",
+        "lpad-align": "1.1.2"
       }
     },
     "srcset": {
@@ -27260,8 +27285,8 @@
       "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
       "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
       "requires": {
-        "array-uniq": "^1.0.2",
-        "number-is-nan": "^1.0.0"
+        "array-uniq": "1.0.3",
+        "number-is-nan": "1.0.1"
       }
     },
     "sshpk": {
@@ -27269,14 +27294,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "stable": {
@@ -27310,8 +27335,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -27319,7 +27344,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -27329,11 +27354,11 @@
       "resolved": "https://registry.npmjs.org/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-3.4.1.tgz",
       "integrity": "sha1-buIkaIMLxUZ5ijfg/Kb9aZzJO4E=",
       "requires": {
-        "bluebird": "^3.0.5",
-        "cheerio": "^0.22.0",
-        "eval": "^0.1.0",
-        "url": "^0.11.0",
-        "webpack-sources": "^0.2.0"
+        "bluebird": "3.5.1",
+        "cheerio": "0.22.0",
+        "eval": "0.1.2",
+        "url": "0.11.0",
+        "webpack-sources": "0.2.3"
       },
       "dependencies": {
         "source-list-map": {
@@ -27346,8 +27371,8 @@
           "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
           "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
           "requires": {
-            "source-list-map": "^1.1.1",
-            "source-map": "~0.5.3"
+            "source-list-map": "1.1.2",
+            "source-map": "0.5.7"
           }
         }
       }
@@ -27368,7 +27393,7 @@
       "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
       "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
       "requires": {
-        "graceful-fs": "^4.1.3"
+        "graceful-fs": "4.1.11"
       }
     },
     "stream-browserify": {
@@ -27376,8 +27401,8 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "stream-cache": {
@@ -27391,8 +27416,8 @@
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
+        "duplexer": "0.1.1",
+        "through": "2.3.8"
       }
     },
     "stream-combiner2": {
@@ -27400,8 +27425,8 @@
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "requires": {
-        "duplexer2": "~0.1.0",
-        "readable-stream": "^2.0.2"
+        "duplexer2": "0.1.4",
+        "readable-stream": "2.3.6"
       }
     },
     "stream-consume": {
@@ -27415,11 +27440,11 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
       "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       }
     },
     "stream-parser": {
@@ -27427,7 +27452,7 @@
       "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
       "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=",
       "requires": {
-        "debug": "2"
+        "debug": "2.6.9"
       }
     },
     "stream-shift": {
@@ -27445,7 +27470,7 @@
       "resolved": "https://registry.npmjs.org/stream-to-buffer/-/stream-to-buffer-0.1.0.tgz",
       "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
       "requires": {
-        "stream-to": "~0.2.0"
+        "stream-to": "0.2.2"
       }
     },
     "strict-uri-encode": {
@@ -27458,7 +27483,7 @@
       "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-1.2.0.tgz",
       "integrity": "sha1-11FTyzg4RjGLejmo2SkrtNtOnDA=",
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "4.17.10"
       }
     },
     "string-width": {
@@ -27466,8 +27491,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -27480,7 +27505,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -27490,7 +27515,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringify-entities": {
@@ -27498,10 +27523,10 @@
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
       "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "requires": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities-html4": "1.1.2",
+        "character-entities-legacy": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "stringmap": {
@@ -27526,7 +27551,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -27539,8 +27564,8 @@
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "1.0.0",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -27548,7 +27573,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -27563,12 +27588,12 @@
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
       "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
       "requires": {
-        "chalk": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "is-absolute": "^0.1.5",
-        "is-natural-number": "^2.0.0",
-        "minimist": "^1.1.0",
-        "sum-up": "^1.0.1"
+        "chalk": "1.1.3",
+        "get-stdin": "4.0.1",
+        "is-absolute": "0.1.7",
+        "is-natural-number": "2.1.1",
+        "minimist": "1.2.0",
+        "sum-up": "1.0.3"
       },
       "dependencies": {
         "is-absolute": {
@@ -27576,7 +27601,7 @@
           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
           "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
           "requires": {
-            "is-relative": "^0.1.0"
+            "is-relative": "0.1.3"
           }
         },
         "is-relative": {
@@ -27604,7 +27629,7 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -27617,7 +27642,7 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "style-loader": {
@@ -27625,7 +27650,7 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
       "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
       "requires": {
-        "loader-utils": "^1.0.2"
+        "loader-utils": "1.1.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -27633,9 +27658,9 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         }
       }
@@ -27651,14 +27676,14 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-2.4.0.tgz",
       "integrity": "sha512-bLW0/lQxTgJ0y+TEllctly+/B0Hz2N82e5AhubP+FIVPSisyOzyFnZzWdqRml7RDwRCsT+EGNN8YYa0VFutT+w==",
       "requires": {
-        "buffer": "^5.0.3",
-        "css-to-react-native": "^2.0.3",
-        "fbjs": "^0.8.9",
-        "hoist-non-react-statics": "^1.2.0",
-        "is-plain-object": "^2.0.1",
-        "prop-types": "^15.5.4",
-        "stylis": "^3.4.0",
-        "supports-color": "^3.2.3"
+        "buffer": "5.1.0",
+        "css-to-react-native": "2.2.0",
+        "fbjs": "0.8.16",
+        "hoist-non-react-statics": "1.2.0",
+        "is-plain-object": "2.0.4",
+        "prop-types": "15.6.1",
+        "stylis": "3.5.0",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "buffer": {
@@ -27666,8 +27691,8 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
           "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "1.3.0",
+            "ieee754": "1.1.11"
           }
         },
         "hoist-non-react-statics": {
@@ -27680,7 +27705,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -27691,19 +27716,19 @@
       "integrity": "sha1-yFHpwteLiplQL3S6PYY7MBY+7JM=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "css-color-list": "^0.0.1",
-        "diff": "^3.2.0",
-        "editorconfig": "^0.13.2",
-        "globby": "^6.1.0",
-        "minimist": "^1.2.0",
-        "postcss": "^6.0.1",
-        "postcss-scss": "^1.0.0",
-        "postcss-sorting": "^2.1.0",
-        "postcss-value-parser": "^3.3.0",
-        "stdin": "^0.0.1",
-        "stylelint": "^7.10.1",
-        "stylelint-order": "^0.4.4"
+        "chalk": "1.1.3",
+        "css-color-list": "0.0.1",
+        "diff": "3.5.0",
+        "editorconfig": "0.13.3",
+        "globby": "6.1.0",
+        "minimist": "1.2.0",
+        "postcss": "6.0.22",
+        "postcss-scss": "1.0.5",
+        "postcss-sorting": "2.1.0",
+        "postcss-value-parser": "3.3.0",
+        "stdin": "0.0.1",
+        "stylelint": "7.13.0",
+        "stylelint-order": "0.4.4"
       },
       "dependencies": {
         "ajv": {
@@ -27712,10 +27737,10 @@
           "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0",
-            "uri-js": "^4.2.1"
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "4.2.1"
           }
         },
         "ajv-keywords": {
@@ -27730,7 +27755,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "balanced-match": {
@@ -27769,9 +27794,9 @@
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           },
           "dependencies": {
             "chalk": {
@@ -27780,9 +27805,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             }
           }
@@ -27793,7 +27818,7 @@
           "integrity": "sha1-xjGwicbM5CK5oQ86lY0r7dOBkyQ=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.21"
+            "postcss": "5.2.18"
           },
           "dependencies": {
             "has-flag": {
@@ -27808,10 +27833,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "^1.1.3",
-                "js-base64": "^2.1.9",
-                "source-map": "^0.5.6",
-                "supports-color": "^3.2.3"
+                "chalk": "1.1.3",
+                "js-base64": "2.4.3",
+                "source-map": "0.5.7",
+                "supports-color": "3.2.3"
               }
             },
             "source-map": {
@@ -27826,7 +27851,7 @@
               "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
-                "has-flag": "^1.0.0"
+                "has-flag": "1.0.0"
               }
             }
           }
@@ -27837,10 +27862,10 @@
           "integrity": "sha1-CeoPN6RExWk4eGBuCbAY6+/3z48=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0",
-            "lodash": "^4.1.0",
-            "log-symbols": "^1.0.2",
-            "postcss": "^5.0.0"
+            "chalk": "1.1.3",
+            "lodash": "4.17.10",
+            "log-symbols": "1.0.2",
+            "postcss": "5.2.18"
           },
           "dependencies": {
             "has-flag": {
@@ -27855,10 +27880,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "^1.1.3",
-                "js-base64": "^2.1.9",
-                "source-map": "^0.5.6",
-                "supports-color": "^3.2.3"
+                "chalk": "1.1.3",
+                "js-base64": "2.4.3",
+                "source-map": "0.5.7",
+                "supports-color": "3.2.3"
               }
             },
             "source-map": {
@@ -27873,7 +27898,7 @@
               "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
-                "has-flag": "^1.0.0"
+                "has-flag": "1.0.0"
               }
             }
           }
@@ -27884,7 +27909,7 @@
           "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0"
+            "is-fullwidth-code-point": "2.0.0"
           }
         },
         "source-map": {
@@ -27899,45 +27924,45 @@
           "integrity": "sha1-ER+Xttpy53XICADWu29fhpmXeF0=",
           "dev": true,
           "requires": {
-            "autoprefixer": "^6.0.0",
-            "balanced-match": "^0.4.0",
-            "chalk": "^2.0.1",
-            "colorguard": "^1.2.0",
-            "cosmiconfig": "^2.1.1",
-            "debug": "^2.6.0",
-            "doiuse": "^2.4.1",
-            "execall": "^1.0.0",
-            "file-entry-cache": "^2.0.0",
-            "get-stdin": "^5.0.0",
-            "globby": "^6.0.0",
-            "globjoin": "^0.1.4",
-            "html-tags": "^2.0.0",
-            "ignore": "^3.2.0",
-            "imurmurhash": "^0.1.4",
-            "known-css-properties": "^0.2.0",
-            "lodash": "^4.17.4",
-            "log-symbols": "^1.0.2",
-            "mathml-tag-names": "^2.0.0",
-            "meow": "^3.3.0",
-            "micromatch": "^2.3.11",
-            "normalize-selector": "^0.2.0",
-            "pify": "^2.3.0",
-            "postcss": "^5.0.20",
-            "postcss-less": "^0.14.0",
-            "postcss-media-query-parser": "^0.2.0",
-            "postcss-reporter": "^3.0.0",
-            "postcss-resolve-nested-selector": "^0.1.1",
-            "postcss-scss": "^0.4.0",
-            "postcss-selector-parser": "^2.1.1",
-            "postcss-value-parser": "^3.1.1",
-            "resolve-from": "^3.0.0",
-            "specificity": "^0.3.0",
-            "string-width": "^2.0.0",
-            "style-search": "^0.1.0",
-            "stylehacks": "^2.3.2",
-            "sugarss": "^0.2.0",
-            "svg-tags": "^1.0.0",
-            "table": "^4.0.1"
+            "autoprefixer": "6.7.7",
+            "balanced-match": "0.4.2",
+            "chalk": "2.4.1",
+            "colorguard": "1.2.1",
+            "cosmiconfig": "2.2.2",
+            "debug": "2.6.9",
+            "doiuse": "2.6.0",
+            "execall": "1.0.0",
+            "file-entry-cache": "2.0.0",
+            "get-stdin": "5.0.1",
+            "globby": "6.1.0",
+            "globjoin": "0.1.4",
+            "html-tags": "2.0.0",
+            "ignore": "3.3.8",
+            "imurmurhash": "0.1.4",
+            "known-css-properties": "0.2.0",
+            "lodash": "4.17.10",
+            "log-symbols": "1.0.2",
+            "mathml-tag-names": "2.1.0",
+            "meow": "3.7.0",
+            "micromatch": "2.3.11",
+            "normalize-selector": "0.2.0",
+            "pify": "2.3.0",
+            "postcss": "5.2.18",
+            "postcss-less": "0.14.0",
+            "postcss-media-query-parser": "0.2.3",
+            "postcss-reporter": "3.0.0",
+            "postcss-resolve-nested-selector": "0.1.1",
+            "postcss-scss": "0.4.1",
+            "postcss-selector-parser": "2.2.3",
+            "postcss-value-parser": "3.3.0",
+            "resolve-from": "3.0.0",
+            "specificity": "0.3.2",
+            "string-width": "2.1.1",
+            "style-search": "0.1.0",
+            "stylehacks": "2.3.2",
+            "sugarss": "0.2.0",
+            "svg-tags": "1.0.0",
+            "table": "4.0.3"
           },
           "dependencies": {
             "chalk": {
@@ -27946,9 +27971,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             },
             "has-flag": {
@@ -27963,10 +27988,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "^1.1.3",
-                "js-base64": "^2.1.9",
-                "source-map": "^0.5.6",
-                "supports-color": "^3.2.3"
+                "chalk": "1.1.3",
+                "js-base64": "2.4.3",
+                "source-map": "0.5.7",
+                "supports-color": "3.2.3"
               },
               "dependencies": {
                 "ansi-styles": {
@@ -27981,11 +28006,11 @@
                   "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "^2.2.1",
-                    "escape-string-regexp": "^1.0.2",
-                    "has-ansi": "^2.0.0",
-                    "strip-ansi": "^3.0.0",
-                    "supports-color": "^2.0.0"
+                    "ansi-styles": "2.2.1",
+                    "escape-string-regexp": "1.0.5",
+                    "has-ansi": "2.0.0",
+                    "strip-ansi": "3.0.1",
+                    "supports-color": "2.0.0"
                   },
                   "dependencies": {
                     "supports-color": {
@@ -28002,7 +28027,7 @@
                   "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                   "dev": true,
                   "requires": {
-                    "has-flag": "^1.0.0"
+                    "has-flag": "1.0.0"
                   }
                 }
               }
@@ -28013,7 +28038,7 @@
               "integrity": "sha1-rXcbgfD3L19IRdCKpg+TVXZT1Uw=",
               "dev": true,
               "requires": {
-                "postcss": "^5.2.13"
+                "postcss": "5.2.18"
               }
             },
             "source-map": {
@@ -28030,7 +28055,7 @@
           "integrity": "sha1-rDQjdWMyfG/4l7ZHQr9q7BkK054=",
           "dev": true,
           "requires": {
-            "postcss": "^5.2.4"
+            "postcss": "5.2.18"
           },
           "dependencies": {
             "has-flag": {
@@ -28045,10 +28070,10 @@
               "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
-                "chalk": "^1.1.3",
-                "js-base64": "^2.1.9",
-                "source-map": "^0.5.6",
-                "supports-color": "^3.2.3"
+                "chalk": "1.1.3",
+                "js-base64": "2.4.3",
+                "source-map": "0.5.7",
+                "supports-color": "3.2.3"
               }
             },
             "source-map": {
@@ -28063,7 +28088,7 @@
               "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
-                "has-flag": "^1.0.0"
+                "has-flag": "1.0.0"
               }
             }
           }
@@ -28074,7 +28099,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "table": {
@@ -28083,12 +28108,12 @@
           "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
           "dev": true,
           "requires": {
-            "ajv": "^6.0.1",
-            "ajv-keywords": "^3.0.0",
-            "chalk": "^2.1.0",
-            "lodash": "^4.17.4",
+            "ajv": "6.5.0",
+            "ajv-keywords": "3.2.0",
+            "chalk": "2.4.1",
+            "lodash": "4.17.10",
             "slice-ansi": "1.0.0",
-            "string-width": "^2.1.1"
+            "string-width": "2.1.1"
           },
           "dependencies": {
             "chalk": {
@@ -28097,9 +28122,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
               }
             }
           }
@@ -28112,16 +28137,16 @@
       "integrity": "sha1-ZMg+BDimjJ7fRJ6MVSp9mrYAmws=",
       "dev": true,
       "requires": {
-        "browserslist": "^1.1.3",
-        "chalk": "^1.1.1",
-        "log-symbols": "^1.0.2",
-        "minimist": "^1.2.0",
-        "plur": "^2.1.2",
-        "postcss": "^5.0.18",
-        "postcss-reporter": "^1.3.3",
-        "postcss-selector-parser": "^2.0.0",
-        "read-file-stdin": "^0.2.1",
-        "text-table": "^0.2.0",
+        "browserslist": "1.7.7",
+        "chalk": "1.1.3",
+        "log-symbols": "1.0.2",
+        "minimist": "1.2.0",
+        "plur": "2.1.2",
+        "postcss": "5.2.18",
+        "postcss-reporter": "1.4.1",
+        "postcss-selector-parser": "2.2.3",
+        "read-file-stdin": "0.2.1",
+        "text-table": "0.2.0",
         "write-file-stdout": "0.0.2"
       },
       "dependencies": {
@@ -28131,8 +28156,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000839",
+            "electron-to-chromium": "1.3.45"
           }
         }
       }
@@ -28143,45 +28168,45 @@
       "integrity": "sha512-56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==",
       "dev": true,
       "requires": {
-        "autoprefixer": "^7.1.2",
-        "balanced-match": "^1.0.0",
-        "chalk": "^2.0.1",
-        "cosmiconfig": "^3.1.0",
-        "debug": "^3.0.0",
-        "execall": "^1.0.0",
-        "file-entry-cache": "^2.0.0",
-        "get-stdin": "^5.0.1",
-        "globby": "^7.0.0",
-        "globjoin": "^0.1.4",
-        "html-tags": "^2.0.0",
-        "ignore": "^3.3.3",
-        "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.5.0",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "mathml-tag-names": "^2.0.1",
-        "meow": "^4.0.0",
-        "micromatch": "^2.3.11",
-        "normalize-selector": "^0.2.0",
-        "pify": "^3.0.0",
-        "postcss": "^6.0.6",
-        "postcss-html": "^0.12.0",
-        "postcss-less": "^1.1.0",
-        "postcss-media-query-parser": "^0.2.3",
-        "postcss-reporter": "^5.0.0",
-        "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-safe-parser": "^3.0.1",
-        "postcss-sass": "^0.2.0",
-        "postcss-scss": "^1.0.2",
-        "postcss-selector-parser": "^3.1.0",
-        "postcss-value-parser": "^3.3.0",
-        "resolve-from": "^4.0.0",
-        "specificity": "^0.3.1",
-        "string-width": "^2.1.0",
-        "style-search": "^0.1.0",
-        "sugarss": "^1.0.0",
-        "svg-tags": "^1.0.0",
-        "table": "^4.0.1"
+        "autoprefixer": "7.2.6",
+        "balanced-match": "1.0.0",
+        "chalk": "2.4.1",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "execall": "1.0.0",
+        "file-entry-cache": "2.0.0",
+        "get-stdin": "5.0.1",
+        "globby": "7.1.1",
+        "globjoin": "0.1.4",
+        "html-tags": "2.0.0",
+        "ignore": "3.3.8",
+        "imurmurhash": "0.1.4",
+        "known-css-properties": "0.5.0",
+        "lodash": "4.17.10",
+        "log-symbols": "2.2.0",
+        "mathml-tag-names": "2.1.0",
+        "meow": "4.0.1",
+        "micromatch": "2.3.11",
+        "normalize-selector": "0.2.0",
+        "pify": "3.0.0",
+        "postcss": "6.0.22",
+        "postcss-html": "0.12.0",
+        "postcss-less": "1.1.5",
+        "postcss-media-query-parser": "0.2.3",
+        "postcss-reporter": "5.0.0",
+        "postcss-resolve-nested-selector": "0.1.1",
+        "postcss-safe-parser": "3.0.1",
+        "postcss-sass": "0.2.0",
+        "postcss-scss": "1.0.5",
+        "postcss-selector-parser": "3.1.1",
+        "postcss-value-parser": "3.3.0",
+        "resolve-from": "4.0.0",
+        "specificity": "0.3.2",
+        "string-width": "2.1.1",
+        "style-search": "0.1.0",
+        "sugarss": "1.0.1",
+        "svg-tags": "1.0.0",
+        "table": "4.0.3"
       },
       "dependencies": {
         "ajv": {
@@ -28190,10 +28215,10 @@
           "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0",
-            "uri-js": "^4.2.1"
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "4.2.1"
           }
         },
         "ajv-keywords": {
@@ -28208,7 +28233,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "autoprefixer": {
@@ -28217,12 +28242,12 @@
           "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
           "dev": true,
           "requires": {
-            "browserslist": "^2.11.3",
-            "caniuse-lite": "^1.0.30000805",
-            "normalize-range": "^0.1.2",
-            "num2fraction": "^1.2.2",
-            "postcss": "^6.0.17",
-            "postcss-value-parser": "^3.2.3"
+            "browserslist": "2.11.3",
+            "caniuse-lite": "1.0.30000839",
+            "normalize-range": "0.1.2",
+            "num2fraction": "1.2.2",
+            "postcss": "6.0.22",
+            "postcss-value-parser": "3.3.0"
           }
         },
         "browserslist": {
@@ -28231,8 +28256,8 @@
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000792",
-            "electron-to-chromium": "^1.3.30"
+            "caniuse-lite": "1.0.30000839",
+            "electron-to-chromium": "1.3.45"
           }
         },
         "camelcase-keys": {
@@ -28241,9 +28266,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "chalk": {
@@ -28252,9 +28277,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "cosmiconfig": {
@@ -28263,10 +28288,10 @@
           "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
           "dev": true,
           "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.9.0",
-            "parse-json": "^3.0.0",
-            "require-from-string": "^2.0.1"
+            "is-directory": "0.3.1",
+            "js-yaml": "3.11.0",
+            "parse-json": "3.0.0",
+            "require-from-string": "2.0.2"
           }
         },
         "debug": {
@@ -28296,7 +28321,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "get-stdin": {
@@ -28311,12 +28336,12 @@
           "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
+            "array-union": "1.0.2",
+            "dir-glob": "2.0.0",
+            "glob": "7.1.2",
+            "ignore": "3.3.8",
+            "pify": "3.0.0",
+            "slash": "1.0.0"
           }
         },
         "has-flag": {
@@ -28337,8 +28362,8 @@
           "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
           }
         },
         "known-css-properties": {
@@ -28353,10 +28378,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           },
           "dependencies": {
             "parse-json": {
@@ -28365,8 +28390,8 @@
               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
               "dev": true,
               "requires": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
+                "error-ex": "1.3.1",
+                "json-parse-better-errors": "1.0.2"
               }
             }
           }
@@ -28377,7 +28402,7 @@
           "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1"
+            "chalk": "2.4.1"
           }
         },
         "map-obj": {
@@ -28392,15 +28417,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -28409,7 +28434,7 @@
           "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1"
+            "error-ex": "1.3.1"
           }
         },
         "path-type": {
@@ -28418,7 +28443,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "postcss": {
@@ -28427,9 +28452,9 @@
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "postcss-reporter": {
@@ -28438,10 +28463,10 @@
           "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1",
-            "lodash": "^4.17.4",
-            "log-symbols": "^2.0.0",
-            "postcss": "^6.0.8"
+            "chalk": "2.4.1",
+            "lodash": "4.17.10",
+            "log-symbols": "2.2.0",
+            "postcss": "6.0.22"
           }
         },
         "postcss-selector-parser": {
@@ -28450,9 +28475,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "dot-prop": "4.2.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         },
         "read-pkg": {
@@ -28461,9 +28486,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -28472,8 +28497,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -28482,8 +28507,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "require-from-string": {
@@ -28504,7 +28529,7 @@
           "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0"
+            "is-fullwidth-code-point": "2.0.0"
           }
         },
         "source-map": {
@@ -28525,7 +28550,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "table": {
@@ -28534,12 +28559,12 @@
           "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
           "dev": true,
           "requires": {
-            "ajv": "^6.0.1",
-            "ajv-keywords": "^3.0.0",
-            "chalk": "^2.1.0",
-            "lodash": "^4.17.4",
+            "ajv": "6.5.0",
+            "ajv-keywords": "3.2.0",
+            "chalk": "2.4.1",
+            "lodash": "4.17.10",
             "slice-ansi": "1.0.0",
-            "string-width": "^2.1.1"
+            "string-width": "2.1.1"
           }
         },
         "trim-newlines": {
@@ -28562,7 +28587,7 @@
       "integrity": "sha512-G8jMZ0KsaVH7leur9XLZVhwOBHZ2vdbuJV8Bgy0ta7/PpBhEHo6fjVDaNchyCGXB5sRcWVq6O9rEU/MvY9cQDQ==",
       "dev": true,
       "requires": {
-        "stylelint-config-recommended": "^1.0.0"
+        "stylelint-config-recommended": "1.0.0"
       }
     },
     "stylelint-order": {
@@ -28571,9 +28596,9 @@
       "integrity": "sha1-2338oFQbUGIBDH4uIedFeR/AiKw=",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.4",
-        "postcss": "^5.2.16",
-        "stylelint": "^7.9.0"
+        "lodash": "4.17.10",
+        "postcss": "5.2.18",
+        "stylelint": "7.13.0"
       },
       "dependencies": {
         "ajv": {
@@ -28582,10 +28607,10 @@
           "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0",
-            "uri-js": "^4.2.1"
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "4.2.1"
           }
         },
         "ajv-keywords": {
@@ -28600,7 +28625,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "balanced-match": {
@@ -28615,9 +28640,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "fast-deep-equal": {
@@ -28650,7 +28675,7 @@
           "integrity": "sha1-xjGwicbM5CK5oQ86lY0r7dOBkyQ=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.21"
+            "postcss": "5.2.18"
           }
         },
         "postcss-reporter": {
@@ -28659,10 +28684,10 @@
           "integrity": "sha1-CeoPN6RExWk4eGBuCbAY6+/3z48=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0",
-            "lodash": "^4.1.0",
-            "log-symbols": "^1.0.2",
-            "postcss": "^5.0.0"
+            "chalk": "1.1.3",
+            "lodash": "4.17.10",
+            "log-symbols": "1.0.2",
+            "postcss": "5.2.18"
           },
           "dependencies": {
             "ansi-styles": {
@@ -28677,11 +28702,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
               }
             },
             "supports-color": {
@@ -28698,7 +28723,7 @@
           "integrity": "sha1-rXcbgfD3L19IRdCKpg+TVXZT1Uw=",
           "dev": true,
           "requires": {
-            "postcss": "^5.2.13"
+            "postcss": "5.2.18"
           }
         },
         "slice-ansi": {
@@ -28707,7 +28732,7 @@
           "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0"
+            "is-fullwidth-code-point": "2.0.0"
           }
         },
         "stylelint": {
@@ -28716,45 +28741,45 @@
           "integrity": "sha1-ER+Xttpy53XICADWu29fhpmXeF0=",
           "dev": true,
           "requires": {
-            "autoprefixer": "^6.0.0",
-            "balanced-match": "^0.4.0",
-            "chalk": "^2.0.1",
-            "colorguard": "^1.2.0",
-            "cosmiconfig": "^2.1.1",
-            "debug": "^2.6.0",
-            "doiuse": "^2.4.1",
-            "execall": "^1.0.0",
-            "file-entry-cache": "^2.0.0",
-            "get-stdin": "^5.0.0",
-            "globby": "^6.0.0",
-            "globjoin": "^0.1.4",
-            "html-tags": "^2.0.0",
-            "ignore": "^3.2.0",
-            "imurmurhash": "^0.1.4",
-            "known-css-properties": "^0.2.0",
-            "lodash": "^4.17.4",
-            "log-symbols": "^1.0.2",
-            "mathml-tag-names": "^2.0.0",
-            "meow": "^3.3.0",
-            "micromatch": "^2.3.11",
-            "normalize-selector": "^0.2.0",
-            "pify": "^2.3.0",
-            "postcss": "^5.0.20",
-            "postcss-less": "^0.14.0",
-            "postcss-media-query-parser": "^0.2.0",
-            "postcss-reporter": "^3.0.0",
-            "postcss-resolve-nested-selector": "^0.1.1",
-            "postcss-scss": "^0.4.0",
-            "postcss-selector-parser": "^2.1.1",
-            "postcss-value-parser": "^3.1.1",
-            "resolve-from": "^3.0.0",
-            "specificity": "^0.3.0",
-            "string-width": "^2.0.0",
-            "style-search": "^0.1.0",
-            "stylehacks": "^2.3.2",
-            "sugarss": "^0.2.0",
-            "svg-tags": "^1.0.0",
-            "table": "^4.0.1"
+            "autoprefixer": "6.7.7",
+            "balanced-match": "0.4.2",
+            "chalk": "2.4.1",
+            "colorguard": "1.2.1",
+            "cosmiconfig": "2.2.2",
+            "debug": "2.6.9",
+            "doiuse": "2.6.0",
+            "execall": "1.0.0",
+            "file-entry-cache": "2.0.0",
+            "get-stdin": "5.0.1",
+            "globby": "6.1.0",
+            "globjoin": "0.1.4",
+            "html-tags": "2.0.0",
+            "ignore": "3.3.8",
+            "imurmurhash": "0.1.4",
+            "known-css-properties": "0.2.0",
+            "lodash": "4.17.10",
+            "log-symbols": "1.0.2",
+            "mathml-tag-names": "2.1.0",
+            "meow": "3.7.0",
+            "micromatch": "2.3.11",
+            "normalize-selector": "0.2.0",
+            "pify": "2.3.0",
+            "postcss": "5.2.18",
+            "postcss-less": "0.14.0",
+            "postcss-media-query-parser": "0.2.3",
+            "postcss-reporter": "3.0.0",
+            "postcss-resolve-nested-selector": "0.1.1",
+            "postcss-scss": "0.4.1",
+            "postcss-selector-parser": "2.2.3",
+            "postcss-value-parser": "3.3.0",
+            "resolve-from": "3.0.0",
+            "specificity": "0.3.2",
+            "string-width": "2.1.1",
+            "style-search": "0.1.0",
+            "stylehacks": "2.3.2",
+            "sugarss": "0.2.0",
+            "svg-tags": "1.0.0",
+            "table": "4.0.3"
           }
         },
         "sugarss": {
@@ -28763,7 +28788,7 @@
           "integrity": "sha1-rDQjdWMyfG/4l7ZHQr9q7BkK054=",
           "dev": true,
           "requires": {
-            "postcss": "^5.2.4"
+            "postcss": "5.2.18"
           }
         },
         "supports-color": {
@@ -28772,7 +28797,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "table": {
@@ -28781,12 +28806,12 @@
           "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
           "dev": true,
           "requires": {
-            "ajv": "^6.0.1",
-            "ajv-keywords": "^3.0.0",
-            "chalk": "^2.1.0",
-            "lodash": "^4.17.4",
+            "ajv": "6.5.0",
+            "ajv-keywords": "3.2.0",
+            "chalk": "2.4.1",
+            "lodash": "4.17.10",
             "slice-ansi": "1.0.0",
-            "string-width": "^2.1.1"
+            "string-width": "2.1.1"
           }
         }
       }
@@ -28801,7 +28826,7 @@
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
       "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
       "requires": {
-        "postcss": "^6.0.14"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "ansi-styles": {
@@ -28809,7 +28834,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -28817,9 +28842,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -28832,9 +28857,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -28847,7 +28872,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -28857,7 +28882,7 @@
       "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "supports-color": {
@@ -28876,13 +28901,13 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "requires": {
-        "coa": "~1.0.1",
-        "colors": "~1.1.2",
-        "csso": "~2.3.1",
-        "js-yaml": "~3.7.0",
-        "mkdirp": "~0.5.1",
-        "sax": "~1.2.1",
-        "whet.extend": "~0.9.9"
+        "coa": "1.0.4",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.4",
+        "whet.extend": "0.9.9"
       }
     },
     "sw-precache": {
@@ -28890,16 +28915,16 @@
       "resolved": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.1.tgz",
       "integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
       "requires": {
-        "dom-urls": "^1.1.0",
-        "es6-promise": "^4.0.5",
-        "glob": "^7.1.1",
-        "lodash.defaults": "^4.2.0",
-        "lodash.template": "^4.4.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "pretty-bytes": "^4.0.2",
-        "sw-toolbox": "^3.4.0",
-        "update-notifier": "^2.3.0"
+        "dom-urls": "1.1.0",
+        "es6-promise": "4.2.4",
+        "glob": "7.1.2",
+        "lodash.defaults": "4.2.0",
+        "lodash.template": "4.4.0",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "pretty-bytes": "4.0.2",
+        "sw-toolbox": "3.6.0",
+        "update-notifier": "2.5.0"
       }
     },
     "sw-toolbox": {
@@ -28907,8 +28932,8 @@
       "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
       "requires": {
-        "path-to-regexp": "^1.0.1",
-        "serviceworker-cache-polyfill": "^4.0.0"
+        "path-to-regexp": "1.7.0",
+        "serviceworker-cache-polyfill": "4.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -28965,23 +28990,23 @@
       "integrity": "sha512-ual5RmcBt7yeXrmpEQIHmITZpNIf289hCTixo/gSOQpdVLLC5v7/W//qn3ZgK6YNdUBptS4szaGVrh7LxOqSHg==",
       "optional": true,
       "requires": {
-        "babel-core": "^6.24.1",
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-plugin-transform-amd-system-wrapper": "^0.3.7",
-        "babel-plugin-transform-cjs-system-wrapper": "^0.6.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.6.5",
-        "babel-plugin-transform-global-system-wrapper": "^0.3.4",
-        "babel-plugin-transform-system-register": "^0.0.1",
-        "bluebird": "^3.3.4",
+        "babel-core": "6.26.3",
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-amd-system-wrapper": "0.3.7",
+        "babel-plugin-transform-cjs-system-wrapper": "0.6.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-global-system-wrapper": "0.3.4",
+        "babel-plugin-transform-system-register": "0.0.1",
+        "bluebird": "3.5.1",
         "data-uri-to-buffer": "0.0.4",
-        "es6-template-strings": "^2.0.0",
-        "glob": "^7.0.3",
-        "mkdirp": "^0.5.1",
-        "rollup": "^0.58.2",
-        "source-map": "^0.5.3",
-        "systemjs": "^0.19.46",
+        "es6-template-strings": "2.0.1",
+        "glob": "7.1.2",
+        "mkdirp": "0.5.1",
+        "rollup": "0.58.2",
+        "source-map": "0.5.7",
+        "systemjs": "0.19.47",
         "traceur": "0.0.105",
-        "uglify-js": "^2.6.1"
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "systemjs": {
@@ -28990,7 +29015,7 @@
           "integrity": "sha1-yMk5NxgPP1SBx2nNJyB2P7SjHG8=",
           "optional": true,
           "requires": {
-            "when": "^3.7.5"
+            "when": "3.7.8"
           }
         }
       }
@@ -29001,12 +29026,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "^4.7.0",
-        "ajv-keywords": "^1.0.0",
-        "chalk": "^1.1.1",
-        "lodash": "^4.0.0",
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.10",
         "slice-ansi": "0.0.4",
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ajv": {
@@ -29015,8 +29040,8 @@
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         }
       }
@@ -29037,13 +29062,13 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.2.tgz",
       "integrity": "sha512-BfkE9CciGGgDsATqkikUHrQrraBCO+ke/1f6SFAEMnxyyfN9lxC+nW1NFWMpqH865DhHIy9vQi682gk1X7friw==",
       "requires": {
-        "chownr": "^1.0.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.2.4",
-        "minizlib": "^1.1.0",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "chownr": "1.0.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.3.0",
+        "minizlib": "1.1.0",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       },
       "dependencies": {
         "yallist": {
@@ -29058,10 +29083,10 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.2.tgz",
       "integrity": "sha512-LdknWjPEiZC1nOBwhv0JBzfJBGPJar08dZg2rwZe0ZTLQoRGEzgrl7vF3qUEkCHpI/wN9e7RyCuDhMsJUCLPPQ==",
       "requires": {
-        "chownr": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
+        "chownr": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pump": "1.0.3",
+        "tar-stream": "1.6.0"
       }
     },
     "tar-stream": {
@@ -29069,13 +29094,13 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.0.tgz",
       "integrity": "sha512-lh2iAPG/BHNmN6WB9Ybdynk9rEJ5GD/dy4zscHmVlwa1dq2tpE+BH78i5vjYwYVWEaOXGBjzxr89aVACF17Cpw==",
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.1.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "to-buffer": "^1.1.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.2",
+        "buffer-alloc": "1.1.0",
+        "end-of-stream": "1.4.1",
+        "fs-constants": "1.0.0",
+        "readable-stream": "2.3.6",
+        "to-buffer": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "temp-dir": {
@@ -29088,8 +29113,8 @@
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
       "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
       "requires": {
-        "temp-dir": "^1.0.0",
-        "uuid": "^3.0.1"
+        "temp-dir": "1.0.0",
+        "uuid": "3.2.1"
       }
     },
     "term-size": {
@@ -29097,7 +29122,7 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       },
       "dependencies": {
         "execa": {
@@ -29105,13 +29130,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         }
       }
@@ -29131,8 +29156,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "through2-filter": {
@@ -29140,8 +29165,8 @@
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "tildify": {
@@ -29150,7 +29175,7 @@
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "time-stamp": {
@@ -29168,7 +29193,7 @@
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "requires": {
-        "setimmediate": "^1.0.4"
+        "setimmediate": "1.0.5"
       }
     },
     "tiny-emitter": {
@@ -29187,7 +29212,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "tmpl": {
@@ -29201,7 +29226,7 @@
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "requires": {
-        "extend-shallow": "^2.0.1"
+        "extend-shallow": "2.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -29209,7 +29234,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -29239,7 +29264,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -29247,10 +29272,10 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -29258,8 +29283,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -29267,7 +29292,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -29278,9 +29303,9 @@
       "integrity": "sha512-saGC8/lWdGrEoBMLUtgzhRHWAkQMP8gdldA3MOAUhBwTGEb1RSMVcflHGSx4ZJsdEZ9o1qDBCPp47LCPrbZWow==",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.4",
-        "vfile": "^2.0.0",
-        "x-is-function": "^1.0.4"
+        "is-buffer": "1.1.6",
+        "vfile": "2.3.0",
+        "x-is-function": "1.0.4"
       }
     },
     "token-stream": {
@@ -29300,7 +29325,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "tough-cookie": {
@@ -29308,7 +29333,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -29323,11 +29348,11 @@
       "resolved": "https://registry.npmjs.org/traceur/-/traceur-0.0.105.tgz",
       "integrity": "sha1-XPne6D1rd4YcPWxE1ThZrterBHk=",
       "requires": {
-        "commander": "2.9.x",
-        "glob": "5.0.x",
-        "rsvp": "^3.0.13",
-        "semver": "^4.3.3",
-        "source-map-support": "~0.2.8"
+        "commander": "2.9.0",
+        "glob": "5.0.15",
+        "rsvp": "3.6.2",
+        "semver": "4.3.6",
+        "source-map-support": "0.2.10"
       },
       "dependencies": {
         "glob": {
@@ -29335,11 +29360,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -29347,7 +29372,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "semver": {
@@ -29360,7 +29385,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "source-map-support": {
@@ -29393,7 +29418,7 @@
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "trim-right": {
@@ -29444,7 +29469,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -29464,7 +29489,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-is": {
@@ -29473,7 +29498,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.18"
       }
     },
     "type-of": {
@@ -29496,9 +29521,9 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "camelcase": {
@@ -29511,8 +29536,8 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -29521,9 +29546,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -29571,8 +29596,8 @@
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
       "requires": {
-        "sprintf-js": "^1.0.3",
-        "util-deprecate": "^1.0.2"
+        "sprintf-js": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "unherit": {
@@ -29580,8 +29605,8 @@
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
       "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
       "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
+        "inherits": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "unified": {
@@ -29589,12 +29614,12 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
       "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
       "requires": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "trough": "^1.0.0",
-        "vfile": "^2.0.0",
-        "x-is-string": "^0.1.0"
+        "bail": "1.0.3",
+        "extend": "3.0.1",
+        "is-plain-obj": "1.1.0",
+        "trough": "1.0.2",
+        "vfile": "2.3.0",
+        "x-is-string": "0.1.0"
       }
     },
     "unified-args": {
@@ -29603,12 +29628,12 @@
       "integrity": "sha1-jZubitNHvrN/QwVipixNNhtCIg8=",
       "dev": true,
       "requires": {
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.0",
-        "chokidar": "^1.5.1",
-        "minimist": "^1.2.0",
-        "text-table": "^0.2.0",
-        "unified-engine": "^4.0.0"
+        "camelcase": "4.1.0",
+        "chalk": "2.4.1",
+        "chokidar": "1.7.0",
+        "minimist": "1.2.0",
+        "text-table": "0.2.0",
+        "unified-engine": "4.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -29617,7 +29642,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -29626,9 +29651,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -29643,7 +29668,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -29654,25 +29679,25 @@
       "integrity": "sha1-lpKql/1cTsNoiXeeElFL746GP8M=",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.5.1",
-        "debug": "^2.2.0",
-        "fault": "^1.0.0",
-        "fn-name": "^2.0.1",
-        "glob": "^7.0.3",
-        "ignore": "^3.2.0",
-        "is-empty": "^1.0.0",
-        "is-hidden": "^1.0.1",
-        "is-object": "^1.0.1",
-        "js-yaml": "^3.6.1",
-        "load-plugin": "^2.0.0",
-        "parse-json": "^2.2.0",
-        "to-vfile": "^2.0.0",
-        "trough": "^1.0.0",
-        "vfile-reporter": "^4.0.0",
-        "vfile-statistics": "^1.1.0",
-        "x-is-function": "^1.0.4",
-        "x-is-string": "^0.1.0",
-        "xtend": "^4.0.1"
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "fault": "1.0.2",
+        "fn-name": "2.0.1",
+        "glob": "7.1.2",
+        "ignore": "3.3.8",
+        "is-empty": "1.2.0",
+        "is-hidden": "1.1.1",
+        "is-object": "1.0.1",
+        "js-yaml": "3.7.0",
+        "load-plugin": "2.2.2",
+        "parse-json": "2.2.0",
+        "to-vfile": "2.2.0",
+        "trough": "1.0.2",
+        "vfile-reporter": "4.0.0",
+        "vfile-statistics": "1.1.1",
+        "x-is-function": "1.0.4",
+        "x-is-string": "0.1.0",
+        "xtend": "4.0.1"
       }
     },
     "unified-lint-rule": {
@@ -29681,7 +29706,7 @@
       "integrity": "sha512-WkqwMC1aijHE17W3Z1co7aTI+Dzo1jHdwhI66fTClU1yOTbzAsTqlOD6eeR/MI9235Y3nu2jMDcm8GCeq4gaLg==",
       "dev": true,
       "requires": {
-        "wrapped": "^1.0.1"
+        "wrapped": "1.0.1"
       }
     },
     "unified-message-control": {
@@ -29691,8 +29716,8 @@
       "dev": true,
       "requires": {
         "trim": "0.0.1",
-        "unist-util-visit": "^1.0.0",
-        "vfile-location": "^2.0.0"
+        "unist-util-visit": "1.3.1",
+        "vfile-location": "2.0.3"
       }
     },
     "union-value": {
@@ -29700,10 +29725,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -29711,7 +29736,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -29719,10 +29744,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -29737,7 +29762,7 @@
       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
       "requires": {
-        "macaddress": "^0.2.8"
+        "macaddress": "0.2.8"
       }
     },
     "uniqs": {
@@ -29750,8 +29775,8 @@
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "requires": {
-        "json-stable-stringify": "^1.0.0",
-        "through2-filter": "^2.0.0"
+        "json-stable-stringify": "1.0.1",
+        "through2-filter": "2.0.0"
       }
     },
     "unique-string": {
@@ -29759,7 +29784,7 @@
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "unist-builder": {
@@ -29767,7 +29792,7 @@
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.2.tgz",
       "integrity": "sha1-jDuZA+9kvPsRfdfPal2Y/Bs7J7Y=",
       "requires": {
-        "object-assign": "^4.1.0"
+        "object-assign": "4.1.1"
       }
     },
     "unist-util-find-all-after": {
@@ -29776,7 +29801,7 @@
       "integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.0.0"
+        "unist-util-is": "2.1.2"
       }
     },
     "unist-util-generated": {
@@ -29794,7 +29819,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz",
       "integrity": "sha512-GRi04yhng1WqBf5RBzPkOtWAadcZS2gvuOgNn/cyJBYNxtTuyYqTKN0eg4rC1YJwGnzrqfRB3dSKm8cNCjNirg==",
       "requires": {
-        "array-iterate": "^1.0.0"
+        "array-iterate": "1.1.2"
       }
     },
     "unist-util-position": {
@@ -29807,7 +29832,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
       "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
       "requires": {
-        "unist-util-visit": "^1.1.0"
+        "unist-util-visit": "1.3.1"
       }
     },
     "unist-util-select": {
@@ -29815,9 +29840,9 @@
       "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-1.5.0.tgz",
       "integrity": "sha1-qTwr6MD2U4J4A7gTMa3sKqJM2TM=",
       "requires": {
-        "css-selector-parser": "^1.1.0",
-        "debug": "^2.2.0",
-        "nth-check": "^1.0.1"
+        "css-selector-parser": "1.3.0",
+        "debug": "2.6.9",
+        "nth-check": "1.0.1"
       }
     },
     "unist-util-stringify-position": {
@@ -29830,7 +29855,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
       "integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
       "requires": {
-        "unist-util-is": "^2.1.1"
+        "unist-util-is": "2.1.2"
       }
     },
     "unist-util-visit-children": {
@@ -29843,8 +29868,8 @@
       "resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
       "integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
       "requires": {
-        "isnumeric": "^0.2.0",
-        "viewport-dimensions": "^0.2.0"
+        "isnumeric": "0.2.0",
+        "viewport-dimensions": "0.2.0"
       }
     },
     "universalify": {
@@ -29862,8 +29887,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -29871,9 +29896,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -29904,7 +29929,7 @@
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "unzip-response": {
@@ -29931,16 +29956,16 @@
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "1.3.0",
+        "chalk": "2.4.1",
+        "configstore": "3.1.2",
+        "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -29948,7 +29973,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -29956,9 +29981,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "has-flag": {
@@ -29971,7 +29996,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -29981,13 +30006,13 @@
       "resolved": "https://registry.npmjs.org/uport/-/uport-0.6.2.tgz",
       "integrity": "sha512-oMZRSJPpLFpuvs5NR6KPje7LzQK10zn8uwnA42pPGvwEFSepEnI2bGZOr/VaZ+Mp2y+ngHo37SEu9marK1rj3Q==",
       "requires": {
-        "ethjs-util": "^0.1.3",
-        "jsontokens": "^0.7.6",
-        "mnid": "^0.1.1",
-        "nets": "^3.2.0",
-        "tweetnacl": "^1.0.0",
-        "tweetnacl-util": "^0.15.0",
-        "uport-lite": "^1.0.0"
+        "ethjs-util": "0.1.4",
+        "jsontokens": "0.7.7",
+        "mnid": "0.1.1",
+        "nets": "3.2.0",
+        "tweetnacl": "1.0.0",
+        "tweetnacl-util": "0.15.0",
+        "uport-lite": "1.0.2"
       },
       "dependencies": {
         "tweetnacl": {
@@ -30002,18 +30027,18 @@
       "resolved": "https://registry.npmjs.org/uport-connect/-/uport-connect-0.7.3.tgz",
       "integrity": "sha512-znuIEtMbX1Hxrlh8Ukcav4voy7ODTP70sdNiMejxvvYuU/mbGpZjLkjcJIDDF1lvZ4lCVggCxoEN6Ahpg1z1ww==",
       "requires": {
-        "async": "^2.1.4",
-        "ethjs-abi": "^0.1.8",
-        "ethjs-util": "^0.1.3",
-        "ipfs-mini": "^1.0.1",
-        "json-loader": "^0.5.4",
-        "mnid": "^0.1.1",
-        "mobile-detect": "^1.3.5",
-        "nets": "^3.2.0",
-        "qr-image": "^3.1.0",
-        "qs": "^6.2.1",
-        "request": "^2.75.0",
-        "uport": "^0.6.2",
+        "async": "2.6.0",
+        "ethjs-abi": "0.1.9",
+        "ethjs-util": "0.1.4",
+        "ipfs-mini": "1.1.2",
+        "json-loader": "0.5.7",
+        "mnid": "0.1.1",
+        "mobile-detect": "1.4.1",
+        "nets": "3.2.0",
+        "qr-image": "3.2.0",
+        "qs": "6.5.1",
+        "request": "2.85.0",
+        "uport": "0.6.2",
         "web3": "0.19.0"
       }
     },
@@ -30022,8 +30047,8 @@
       "resolved": "https://registry.npmjs.org/uport-lite/-/uport-lite-1.0.2.tgz",
       "integrity": "sha512-qFGt9576p7b4B5+W2jRYoN9Q99lbeprLuUC0wFIRGv0C+gY6yZ6KYN8BlbGfhUUR6pbKIQxy5KWEYvIGByHu7A==",
       "requires": {
-        "base-x": "^3.0.0",
-        "xmlhttprequest": "^1.8.0"
+        "base-x": "3.0.4",
+        "xmlhttprequest": "1.8.0"
       }
     },
     "uri-js": {
@@ -30032,7 +30057,7 @@
       "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.0"
       }
     },
     "urijs": {
@@ -30071,9 +30096,9 @@
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
       "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
       "requires": {
-        "loader-utils": "^1.0.2",
-        "mime": "^1.4.1",
-        "schema-utils": "^0.3.0"
+        "loader-utils": "1.1.0",
+        "mime": "1.6.0",
+        "schema-utils": "0.3.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -30081,9 +30106,9 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         }
       }
@@ -30093,8 +30118,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
       "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
       "requires": {
-        "querystringify": "^2.0.0",
-        "requires-port": "^1.0.0"
+        "querystringify": "2.0.0",
+        "requires-port": "1.0.0"
       },
       "dependencies": {
         "querystringify": {
@@ -30109,7 +30134,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "url-regex": {
@@ -30117,7 +30142,7 @@
       "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
       "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
       "requires": {
-        "ip-regex": "^1.0.1"
+        "ip-regex": "1.0.3"
       }
     },
     "url-to-options": {
@@ -30130,7 +30155,7 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -30195,7 +30220,7 @@
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "requires": {
-        "user-home": "^1.1.1"
+        "user-home": "1.1.1"
       }
     },
     "vali-date": {
@@ -30213,8 +30238,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "validator": {
@@ -30242,9 +30267,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vfile": {
@@ -30252,10 +30277,10 @@
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
       "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "requires": {
-        "is-buffer": "^1.1.4",
+        "is-buffer": "1.1.6",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
+        "unist-util-stringify-position": "1.1.2",
+        "vfile-message": "1.0.1"
       }
     },
     "vfile-location": {
@@ -30268,7 +30293,7 @@
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
       "integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "unist-util-stringify-position": "1.1.2"
       }
     },
     "vfile-reporter": {
@@ -30277,11 +30302,11 @@
       "integrity": "sha1-6m8K4TQvSEFXOYXgX5QXNvJ96do=",
       "dev": true,
       "requires": {
-        "repeat-string": "^1.5.0",
-        "string-width": "^1.0.0",
-        "supports-color": "^4.1.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-statistics": "^1.1.0"
+        "repeat-string": "1.6.1",
+        "string-width": "1.0.2",
+        "supports-color": "4.5.0",
+        "unist-util-stringify-position": "1.1.2",
+        "vfile-statistics": "1.1.1"
       },
       "dependencies": {
         "has-flag": {
@@ -30296,7 +30321,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -30305,9 +30330,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "supports-color": {
@@ -30316,7 +30341,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -30337,8 +30362,8 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.4",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       },
       "dependencies": {
@@ -30354,8 +30379,8 @@
       "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
       "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "readable-stream": "^2.0.0"
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.6"
       }
     },
     "vinyl-bufferstream": {
@@ -30372,12 +30397,12 @@
       "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.3.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^2.0.0",
-        "vinyl": "^1.1.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "2.0.0",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "first-chunk-stream": {
@@ -30385,7 +30410,7 @@
           "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
           "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.6"
           }
         },
         "pify": {
@@ -30398,7 +30423,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-bom-stream": {
@@ -30406,8 +30431,8 @@
           "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
           "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
           "requires": {
-            "first-chunk-stream": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "first-chunk-stream": "2.0.0",
+            "strip-bom": "2.0.0"
           }
         }
       }
@@ -30417,23 +30442,23 @@
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "requires": {
-        "duplexify": "^3.2.0",
-        "glob-stream": "^5.3.2",
-        "graceful-fs": "^4.0.0",
+        "duplexify": "3.6.0",
+        "glob-stream": "5.3.5",
+        "graceful-fs": "4.1.11",
         "gulp-sourcemaps": "1.6.0",
-        "is-valid-glob": "^0.3.0",
-        "lazystream": "^1.0.0",
-        "lodash.isequal": "^4.0.0",
-        "merge-stream": "^1.0.0",
-        "mkdirp": "^0.5.0",
-        "object-assign": "^4.0.0",
-        "readable-stream": "^2.0.4",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^1.0.0",
-        "through2": "^2.0.0",
-        "through2-filter": "^2.0.0",
-        "vali-date": "^1.0.0",
-        "vinyl": "^1.0.0"
+        "is-valid-glob": "0.3.0",
+        "lazystream": "1.0.0",
+        "lodash.isequal": "4.5.0",
+        "merge-stream": "1.0.1",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.6",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "1.0.0",
+        "through2": "2.0.3",
+        "through2-filter": "2.0.0",
+        "vali-date": "1.0.0",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -30441,7 +30466,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -30460,7 +30485,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "optional": true,
       "requires": {
-        "makeerror": "1.0.x"
+        "makeerror": "1.0.11"
       }
     },
     "ware": {
@@ -30468,7 +30493,7 @@
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "requires": {
-        "wrap-fn": "^0.1.0"
+        "wrap-fn": "0.1.5"
       }
     },
     "warning": {
@@ -30476,7 +30501,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "watch": {
@@ -30490,9 +30515,9 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
       "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
       "requires": {
-        "async": "^0.9.0",
-        "chokidar": "^1.0.0",
-        "graceful-fs": "^4.1.2"
+        "async": "0.9.2",
+        "chokidar": "1.7.0",
+        "graceful-fs": "4.1.11"
       },
       "dependencies": {
         "async": {
@@ -30519,15 +30544,14 @@
       "integrity": "sha1-ixj7okQhpZ0ohIWby5txjCZlUk4=",
       "requires": {
         "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-        "crypto-js": "^3.1.4",
-        "utf8": "^2.1.1",
-        "xhr2": "*",
-        "xmlhttprequest": "*"
+        "crypto-js": "3.1.8",
+        "utf8": "2.1.2",
+        "xhr2": "0.1.4",
+        "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-          "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
         }
       }
     },
@@ -30536,21 +30560,21 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
       "integrity": "sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=",
       "requires": {
-        "acorn": "^3.0.0",
-        "async": "^1.3.0",
-        "clone": "^1.0.2",
-        "enhanced-resolve": "~0.9.0",
-        "interpret": "^0.6.4",
-        "loader-utils": "^0.2.11",
-        "memory-fs": "~0.3.0",
-        "mkdirp": "~0.5.0",
-        "node-libs-browser": "^0.7.0",
-        "optimist": "~0.6.0",
-        "supports-color": "^3.1.0",
-        "tapable": "~0.1.8",
-        "uglify-js": "~2.7.3",
-        "watchpack": "^0.2.1",
-        "webpack-core": "~0.6.9"
+        "acorn": "3.3.0",
+        "async": "1.5.2",
+        "clone": "1.0.4",
+        "enhanced-resolve": "0.9.1",
+        "interpret": "0.6.6",
+        "loader-utils": "0.2.17",
+        "memory-fs": "0.3.0",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "0.7.0",
+        "optimist": "0.6.1",
+        "supports-color": "3.2.3",
+        "tapable": "0.1.10",
+        "uglify-js": "2.7.5",
+        "watchpack": "0.2.9",
+        "webpack-core": "0.6.9"
       },
       "dependencies": {
         "async": {
@@ -30563,7 +30587,7 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
           "integrity": "sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=",
           "requires": {
-            "inherits": "^2.0.1"
+            "inherits": "2.0.3"
           }
         },
         "browserify-zlib": {
@@ -30571,7 +30595,7 @@
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "requires": {
-            "pako": "~0.2.0"
+            "pako": "0.2.9"
           }
         },
         "camelcase": {
@@ -30584,8 +30608,8 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -30610,28 +30634,28 @@
           "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
           "integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
           "requires": {
-            "assert": "^1.1.1",
-            "browserify-zlib": "^0.1.4",
-            "buffer": "^4.9.0",
-            "console-browserify": "^1.1.0",
-            "constants-browserify": "^1.0.0",
+            "assert": "1.4.1",
+            "browserify-zlib": "0.1.4",
+            "buffer": "4.9.1",
+            "console-browserify": "1.1.0",
+            "constants-browserify": "1.0.0",
             "crypto-browserify": "3.3.0",
-            "domain-browser": "^1.1.1",
-            "events": "^1.0.0",
+            "domain-browser": "1.2.0",
+            "events": "1.1.1",
             "https-browserify": "0.0.1",
-            "os-browserify": "^0.2.0",
+            "os-browserify": "0.2.1",
             "path-browserify": "0.0.0",
-            "process": "^0.11.0",
-            "punycode": "^1.2.4",
-            "querystring-es3": "^0.2.0",
-            "readable-stream": "^2.0.5",
-            "stream-browserify": "^2.0.1",
-            "stream-http": "^2.3.1",
-            "string_decoder": "^0.10.25",
-            "timers-browserify": "^2.0.2",
+            "process": "0.11.10",
+            "punycode": "1.4.1",
+            "querystring-es3": "0.2.1",
+            "readable-stream": "2.3.6",
+            "stream-browserify": "2.0.1",
+            "stream-http": "2.8.2",
+            "string_decoder": "0.10.31",
+            "timers-browserify": "2.0.10",
             "tty-browserify": "0.0.0",
-            "url": "^0.11.0",
-            "util": "^0.10.3",
+            "url": "0.11.0",
+            "util": "0.10.3",
             "vm-browserify": "0.0.4"
           }
         },
@@ -30670,7 +30694,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         },
         "uglify-js": {
@@ -30678,10 +30702,10 @@
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
           "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
           "requires": {
-            "async": "~0.2.6",
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "async": "0.2.10",
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
             "async": {
@@ -30696,8 +30720,8 @@
           "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
           "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
           "requires": {
-            "source-list-map": "~0.1.7",
-            "source-map": "~0.4.1"
+            "source-list-map": "0.1.8",
+            "source-map": "0.4.4"
           },
           "dependencies": {
             "source-map": {
@@ -30705,7 +30729,7 @@
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "requires": {
-                "amdefine": ">=0.0.4"
+                "amdefine": "1.0.1"
               }
             }
           }
@@ -30715,9 +30739,9 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -30743,7 +30767,7 @@
       "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.4.8.tgz",
       "integrity": "sha1-B/xVq6gdF9uoyuWkPWvWkjb4tfg=",
       "requires": {
-        "source-map": "~0.1.38"
+        "source-map": "0.1.43"
       },
       "dependencies": {
         "source-map": {
@@ -30751,7 +30775,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -30761,11 +30785,11 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
       "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
       "requires": {
-        "memory-fs": "~0.4.1",
-        "mime": "^1.5.0",
-        "path-is-absolute": "^1.0.0",
-        "range-parser": "^1.0.3",
-        "time-stamp": "^2.0.0"
+        "memory-fs": "0.4.1",
+        "mime": "1.6.0",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.2.0",
+        "time-stamp": "2.0.0"
       },
       "dependencies": {
         "memory-fs": {
@@ -30773,8 +30797,8 @@
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
           "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
           "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
+            "errno": "0.1.7",
+            "readable-stream": "2.3.6"
           }
         }
       }
@@ -30784,19 +30808,19 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz",
       "integrity": "sha1-DL1fLSrI1OWTqs1clwLnu9XlmJI=",
       "requires": {
-        "compression": "^1.5.2",
-        "connect-history-api-fallback": "^1.3.0",
-        "express": "^4.13.3",
-        "http-proxy-middleware": "~0.17.1",
+        "compression": "1.7.2",
+        "connect-history-api-fallback": "1.5.0",
+        "express": "4.16.3",
+        "http-proxy-middleware": "0.17.4",
         "open": "0.0.5",
-        "optimist": "~0.6.1",
-        "serve-index": "^1.7.2",
-        "sockjs": "^0.3.15",
-        "sockjs-client": "^1.0.3",
-        "stream-cache": "~0.0.1",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^3.1.1",
-        "webpack-dev-middleware": "^1.10.2"
+        "optimist": "0.6.1",
+        "serve-index": "1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "stream-cache": "0.0.2",
+        "strip-ansi": "3.0.1",
+        "supports-color": "3.2.3",
+        "webpack-dev-middleware": "1.12.2"
       },
       "dependencies": {
         "supports-color": {
@@ -30804,7 +30828,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -30815,9 +30839,9 @@
       "integrity": "sha512-wbjnvcc3HOPKRE/L0KmTv2MrByfLFOJlVFNKo5Svxy+1plR/bMIMYQDgB4pUOzJXhiBLU7Clp6P1SSzS89iKxA==",
       "requires": {
         "ansi-html": "0.0.7",
-        "html-entities": "^1.2.0",
-        "querystring": "^0.2.0",
-        "strip-ansi": "^3.0.0"
+        "html-entities": "1.2.1",
+        "querystring": "0.2.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "webpack-md5-hash": {
@@ -30825,7 +30849,7 @@
       "resolved": "https://registry.npmjs.org/webpack-md5-hash/-/webpack-md5-hash-0.0.5.tgz",
       "integrity": "sha1-2fGJnq1mRFndi2sMkmrHHPvXvHo=",
       "requires": {
-        "md5": "^2.0.0"
+        "md5": "2.2.1"
       }
     },
     "webpack-sources": {
@@ -30833,8 +30857,8 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
       "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
       "requires": {
-        "source-list-map": "~0.1.7",
-        "source-map": "~0.5.3"
+        "source-list-map": "0.1.8",
+        "source-map": "0.5.7"
       }
     },
     "webpack-stats-plugin": {
@@ -30851,8 +30875,8 @@
         "chalk": "1.1.3",
         "commander": "2.9.0",
         "common-tags": "0.1.1",
-        "cross-env": "^3.1.1",
-        "find-node-modules": "^1.0.1",
+        "cross-env": "3.2.4",
+        "find-node-modules": "1.0.4",
         "joi": "9.0.0-0",
         "lodash": "4.11.1",
         "npmlog": "2.0.3",
@@ -30870,9 +30894,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "common-tags": {
@@ -30880,7 +30904,7 @@
           "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-0.1.1.tgz",
           "integrity": "sha1-2JNIbsxt8iz/5sOTyIwS9x5+iHE=",
           "requires": {
-            "babel-runtime": "^6.6.1"
+            "babel-runtime": "6.26.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -30888,7 +30912,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isemail": {
@@ -30901,11 +30925,11 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-9.0.0-0.tgz",
           "integrity": "sha1-p8pCGWAhSa4Np6fFyh1j08eeCWs=",
           "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "moment": "2.x.x",
-            "topo": "2.x.x"
+            "hoek": "4.2.1",
+            "isemail": "2.2.1",
+            "items": "2.1.1",
+            "moment": "2.22.1",
+            "topo": "2.0.2"
           }
         },
         "load-json-file": {
@@ -30913,11 +30937,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "lodash": {
@@ -30930,7 +30954,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "path-type": {
@@ -30938,9 +30962,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -30953,9 +30977,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -30963,8 +30987,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "set-blocking": {
@@ -30977,9 +31001,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-bom": {
@@ -30987,7 +31011,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "window-size": {
@@ -31000,19 +31024,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz",
           "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "pkg-conf": "^1.1.2",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^1.0.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "pkg-conf": "1.1.3",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "1.0.0",
+            "string-width": "1.0.2",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
           }
         },
         "yargs-parser": {
@@ -31020,8 +31044,8 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
           }
         }
       }
@@ -31031,8 +31055,8 @@
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.4.12",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -31061,7 +31085,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -31079,7 +31103,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
-        "string-width": "^1.0.2"
+        "string-width": "1.0.2"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -31087,7 +31111,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -31095,9 +31119,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -31107,7 +31131,7 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "requires": {
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       }
     },
     "window-size": {
@@ -31125,8 +31149,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -31134,7 +31158,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -31142,9 +31166,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -31171,7 +31195,7 @@
       "dev": true,
       "requires": {
         "co": "3.1.0",
-        "sliced": "^1.0.1"
+        "sliced": "1.0.1"
       },
       "dependencies": {
         "co": {
@@ -31193,7 +31217,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -31201,9 +31225,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "write-file-stdout": {
@@ -31219,12 +31243,12 @@
       "dev": true,
       "requires": {
         "adverb-where": "0.0.9",
-        "e-prime": "^0.10.2",
-        "no-cliches": "^0.1.0",
-        "object.assign": "^4.0.4",
-        "passive-voice": "^0.1.0",
-        "too-wordy": "^0.1.4",
-        "weasel-words": "^0.1.1"
+        "e-prime": "0.10.2",
+        "no-cliches": "0.1.0",
+        "object.assign": "4.1.0",
+        "passive-voice": "0.1.0",
+        "too-wordy": "0.1.4",
+        "weasel-words": "0.1.1"
       }
     },
     "ws": {
@@ -31232,8 +31256,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.0.0.tgz",
       "integrity": "sha1-mN2wAFbIOQy3Ued4h4hJf5kQO2w=",
       "requires": {
-        "safe-buffer": "~5.0.1",
-        "ultron": "~1.1.0"
+        "safe-buffer": "5.0.1",
+        "ultron": "1.1.1"
       },
       "dependencies": {
         "safe-buffer": {
@@ -31269,10 +31293,10 @@
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
       "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
       "requires": {
-        "global": "~4.3.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
+        "global": "4.3.2",
+        "is-function": "1.0.1",
+        "parse-headers": "2.0.1",
+        "xtend": "4.0.1"
       }
     },
     "xhr2": {
@@ -31295,8 +31319,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
@@ -31334,7 +31358,7 @@
       "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.4.0.tgz",
       "integrity": "sha1-Sq5EfRPBqnOpidiipTCbCxo8o1M=",
       "requires": {
-        "js-yaml": "^3.5.2"
+        "js-yaml": "3.7.0"
       }
     },
     "yamljs": {
@@ -31342,8 +31366,8 @@
       "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
       "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
       "requires": {
-        "argparse": "^1.0.7",
-        "glob": "^7.0.5"
+        "argparse": "1.0.10",
+        "glob": "7.1.2"
       }
     },
     "yargs": {
@@ -31351,18 +31375,18 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "2.1.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "9.0.2"
       },
       "dependencies": {
         "find-up": {
@@ -31370,7 +31394,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -31380,7 +31404,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
       "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       }
     },
     "yauzl": {
@@ -31388,8 +31412,8 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
       "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.0.1"
       }
     },
     "yeast": {
@@ -31402,22 +31426,22 @@
       "resolved": "https://registry.npmjs.org/yurnalist/-/yurnalist-0.2.1.tgz",
       "integrity": "sha1-LTK5YYq2SRiRwTG9kKUpXhn9S60=",
       "requires": {
-        "chalk": "^1.1.1",
-        "death": "^1.0.0",
-        "debug": "^2.2.0",
-        "detect-indent": "^5.0.0",
-        "inquirer": "^3.0.1",
-        "invariant": "^2.2.0",
-        "is-builtin-module": "^1.0.0",
-        "is-ci": "^1.0.10",
-        "leven": "^2.0.0",
-        "loud-rejection": "^1.2.0",
-        "node-emoji": "^1.0.4",
-        "object-path": "^0.11.2",
-        "read": "^1.0.7",
-        "rimraf": "^2.5.0",
-        "semver": "^5.1.0",
-        "strip-bom": "^3.0.0"
+        "chalk": "1.1.3",
+        "death": "1.1.0",
+        "debug": "2.6.9",
+        "detect-indent": "5.0.0",
+        "inquirer": "3.3.0",
+        "invariant": "2.2.4",
+        "is-builtin-module": "1.0.0",
+        "is-ci": "1.1.0",
+        "leven": "2.1.0",
+        "loud-rejection": "1.6.0",
+        "node-emoji": "1.8.1",
+        "object-path": "0.11.4",
+        "read": "1.0.7",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "strip-bom": "3.0.0"
       },
       "dependencies": {
         "detect-indent": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-icons": "^2.2.7",
     "react-share": "^1.19.1",
     "react-twitter-widgets": "^1.4.0",
+    "rehype-react": "^3.0.2",
     "styled-components": "^2.4.0",
     "sugarss": "^1.0.1",
     "uport": "^0.6.2",

--- a/src/components/Layout/TableOfContents.jsx
+++ b/src/components/Layout/TableOfContents.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Link from 'gatsby-link'
 import styled from 'styled-components'
 import _ from 'lodash'
+import { cleanDoubleByteChars } from '../../helpers/cleanDoubleByteChars'
 
 export default class TableOfContents extends React.Component {
   render () {
@@ -35,10 +36,10 @@ export default class TableOfContents extends React.Component {
           if (node.depth === 2) {
             chapterContents.push(
               <ContentContainer key={`${node.value}`}>
-                <Link to={`${cat.path}#${_.kebabCase(node.value)}`}>
+                <Link to={`${cat.path}#${cleanDoubleByteChars(_.kebabCase(node.value))}`}>
                   <li>
                     <span>
-                      {_.kebabCase(node.value) === urlHash
+                      {cleanDoubleByteChars(_.kebabCase(node.value)) === urlHash
                         ? <h6 className='active'>{node.value}</h6>
                         : <h6>{node.value}</h6>
                       }

--- a/src/components/Layout/html/SecondaryTitle.jsx
+++ b/src/components/Layout/html/SecondaryTitle.jsx
@@ -1,10 +1,17 @@
 import React, {Component} from 'react'
+import _ from 'lodash'
+import { cleanDoubleByteChars } from '../../../helpers/cleanDoubleByteChars'
 
 class SecondaryTitle extends Component {
   render () {
+    const h2Text = this.props.children[1]
+    const svgAnchor = this.props.children[0].props.children[0]
     return (
-      <h2 id={this.props.id}>
-        {this.props.children}
+      <h2 id={cleanDoubleByteChars(_.kebabCase(h2Text))}>
+        <a href={'#' + cleanDoubleByteChars(_.kebabCase(h2Text))} aria-hidden='true' className='anchor'>
+          {svgAnchor}
+        </a>
+        {h2Text}
       </h2>
     )
   }

--- a/src/components/Layout/html/SecondaryTitle.jsx
+++ b/src/components/Layout/html/SecondaryTitle.jsx
@@ -1,0 +1,13 @@
+import React, {Component} from 'react'
+
+class SecondaryTitle extends Component {
+  render () {
+    return (
+      <h2 id={this.props.id}>
+        {this.props.children}
+      </h2>
+    )
+  }
+}
+
+export default SecondaryTitle

--- a/src/helpers/cleanDoubleByteChars.js
+++ b/src/helpers/cleanDoubleByteChars.js
@@ -1,0 +1,8 @@
+export function cleanDoubleByteChars (str) {
+  for (var i = 0, n = str.length; i < n; i++) {
+    if (str.charCodeAt(i) > 255) {
+      return str.substring(0, i)
+    }
+  }
+  return str
+}

--- a/src/templates/content.jsx
+++ b/src/templates/content.jsx
@@ -1,33 +1,41 @@
-import React from "react";
-import Helmet from "react-helmet";
-import styled from "styled-components"
+import React from 'react'
+import Helmet from 'react-helmet'
+import styled from 'styled-components'
+import RehypeReact from 'rehype-react'
 
-import SEO from "../components/SEO/SEO"
+import SEO from '../components/SEO/SEO'
 import SiteHeader from '../components/Layout/Header'
-import config from "../../data/SiteConfig"
-import TableOfContents from "../components/Layout/TableOfContents";
+import config from '../../data/SiteConfig'
+import TableOfContents from '../components/Layout/TableOfContents'
+import SecondaryTitle from '../components/Layout/html/SecondaryTitle'
 
 export default class ContentTemplate extends React.Component {
-  render() {
-    const { slug } = this.props.pathContext;
-    const postNode = this.props.data.postBySlug;
-    const post = postNode.frontmatter;
-    const category = post.category;
-    const categories = [];
+  render () {
+    const renderAst = new RehypeReact({
+      createElement: React.createElement,
+      components: {
+        'h2': SecondaryTitle
+      }
+    }).Compiler
+    const { slug } = this.props.pathContext
+    const postNode = this.props.data.postBySlug
+    const post = postNode.frontmatter
+    const category = post.category
+    const categories = []
     this.props.data.postByCategory.edges.forEach(cat => {
-        if(cat.node.frontmatter.category === category){
-            categories.push(cat)
-        }
+      if (cat.node.frontmatter.category === category) {
+        categories.push(cat)
+      }
     })
-    const chapterTitles = [];
+    const chapterTitles = []
     categories.forEach(cat => {
       chapterTitles.push(cat.node.frontmatter.title)
-    });
+    })
     if (!post.id) {
-      post.id = slug;
+      post.id = slug
     }
     if (!post.id) {
-      post.category_id = config.postDefaultCategoryID;
+      post.category_id = config.postDefaultCategoryID
     }
     return (
       <div>
@@ -38,30 +46,27 @@ export default class ContentTemplate extends React.Component {
         <BodyGrid>
           <HeaderContainer>
             <SiteHeader
-            activeCategory={category}
-            location={this.props.location}
-            categories={this.props.data.navCategories}
+              activeCategory={category}
+              location={this.props.location}
+              categories={this.props.data.navCategories}
             />
           </HeaderContainer>
           <ToCContainer>
             <TableOfContents
-            contentsType={post.type}
-            chapterTitles={chapterTitles}
-            categories={categories}
-            category={category}
+              contentsType={post.type}
+              chapterTitles={chapterTitles}
+              categories={categories}
+              category={category}
             />
           </ToCContainer>
           <BodyContainer>
-            <div>
-              {/* <h1>
-                  {post.title}
-                  </h1> */}
-              <div className={`docSearch-content`} dangerouslySetInnerHTML={{ __html: postNode.html }} />
+            <div className={`docSearch-content`}>
+              { renderAst(postNode.htmlAst) }
             </div>
           </BodyContainer>
         </BodyGrid>
       </div>
-    );
+    )
   }
 }
 
@@ -137,7 +142,7 @@ const ToCContainer = styled.div`
   }
 `
 
-/* eslint no-undef: "off"*/
+/* eslint no-undef: "off" */
 export const pageQuery = graphql`
   query ContentBySlug($slug: String!) {
     allPostTitles: allMarkdownRemark(
@@ -176,7 +181,7 @@ export const pageQuery = graphql`
       }
     }
     postBySlug: markdownRemark(fields: { slug: { eq: $slug } }) {
-      html
+      htmlAst
       timeToRead
       excerpt
       headings  {


### PR DESCRIPTION
Fix for #28 

Involves using rehype-react to map an html element (h2 in this case) to a react component. I also added a helper function to clean special doubleByte characters from anchor links in the body content and left side Table of Contents. 