### PR TITLE
Update attest credentials guide

### DIFF
--- a/markdown/docs/guides/AttestCredentials.md
+++ b/markdown/docs/guides/AttestCredentials.md
@@ -8,67 +8,50 @@ source: "https://github.com/uport-project/uport-project.github.io/blob/develop/m
 
 # Attesting Credentials
 
-![diag](diag3.svg)
+One of the core needs of Web 3.0 is to build trust in a self-sovereign world. We establish facts which are not mathematically derived by social consensus. To create social consensus, actors must attest to things being true. uPort provides tools for creating and transferring these credentials between entities represented by Ethereum-based identities.
 
- * **If the user consents, the uPort app saves the attestation token to their device.*
+## Requesting the user to sign a credential
 
-<div class="overview-list" markdown=1>
-
-1. Browser displays a QR code (if desktop) or loads a URI that opens the uPort app (if mobile) to initiate the login / share data flow outlined in [requesting credentials](/requestcredentials)
-1. After the user scans (on desktop) or consents to open the app (on mobile), the app displays a card asking the user to share their data. This will always contain the user’s address and may contain a push token as well as any other data the app chooses to request.
-1. If user consents, mobile app posts the address (and maybe also a push token or other data) via Chasqui (if desktop) or encoded in a JWT appended to a URI (if mobile)
-1. Browser grabs the address & data from Chasqui or the URL and removes QR code from UI.
-1. When the app is ready to send an attestation (maybe they completed a background check, maybe the user sent funds, maybe the user shared a piece of personal data), the app encodes the relevant data in a JWT and signs it.
-
-</div>
-<hr>
-
-###### If push is enabled
-
-<div class="overview-list1" markdown=1>
-
-- This attestation token is sent along with the user’s push token to pututu,
-- Pututu checks the signature in the push token against the user’s public key in IPFS, then forwards the attestation token.
-- The user receives a push notification, which opens the app to a card asking if they want to accept the attestation.
-
-</div>
-<hr>
-
-###### If push is not enabled
-
-<div class="overview-list2" markdown=1>
-
-- The attestation token is encoded in a QR code (if desktop) or a URI (if mobile) and the user is told to scan or open the uPort app.
-- After the user scans (desktop) or consents to open the app (mobile), the app displays a card asking if the user wants to accept the attestation
-
-</div>
-<hr>
-
-One of the core needs of Web 3.0 is to build trust in a self-sovereign world. We establish facts which are not mathematically derived by social consensus. To create social consensus, actors must attest to things being true. We can do this with uPort using the `uport.attestCredentials` function.
-
-**NOTE:** Currently only one credential can be pushed at a time. We are working to fix this soon.
-
-## Calling the attest method
+Your app can generate a claim about any identity and request that the user signs it to create a credential.  Read about [working with JWTs](/did-jwt/guides/index.md) to learn more about this process. Once the credential is received, it can be stored and shared with other users or apps.
 
 ```js
-uport.attestCredentials({
-  sub: 'THE_RECEIVING_UPORT_ID',
-  claim: { CUSTOM_PROPERTY: PROPERTY_VALUE },
+const unsignedClaim = {
+  sub: 'did:ethr:0x413daa771a2fc9c5ae5a66abd144881ef2498c54',
+  claim: {
+    'citizen of cryptoville': {
+      'allowed to vote': true,
+      'document': 'QmZZBBKPS2NWc6PMZbUk9zUHCo1SHKzQPPX4ndfwaYzmPW',
+    }
+  }
+}
+uport.createVerificationRequest(unsignedClaim)
+
+uport.onResponse('signClaimReq').then(payload => {
+  // do something with the signed credential
 })
 ```
 
-## Setting an expiration date
+## Relaying an existing credential
 
-We can also optionally add an expiration date.
+Credentials issued to the user from outside the app can sent to them from the app as well. Learn more about creating credentials from our [server-side credentials tutorial](/uport-js/guides/server-side-credentials-example.md).
 
 ```js
-uport.attestCredentials({
+const credential = 'eyJ0eXAiOiJKV1QiLCJh...' // some credential JWT
+uport.send(credential, 'existingCredential')
+
+uport.onResponse('existingCredential').then(payload => {
+  // do something once the user accepts the credential
+})
+```
+
+## Signing a credential about the user in app
+
+Credentials issued from a client-only app using `uport-connect` will be signed by a generated identity. This is due to not being able to use a signing key while concealing it from the user without a server.
+
+```js
+uport.attest({
   sub: 'THE_RECEIVING_UPORT_ID',
   claim: { CUSTOM_PROPERTY: PROPERTY_VALUE },
   exp: new Date().getTime() + 30 * 24 * 60 * 60 * 1000,  // Optional expiration
 })
 ```
-
-## Attesting multiple credentials
-
-**Under construction**


### PR DESCRIPTION
Reasoning for changes

- updated the code blocks to use the correct syntax for major release version of uport-connect
- tried to reduce the information to the minimum necessary for a dev to write and understand code to attest credentials to a uPort client
- assumptions
  - dev already has an instance of uport-connect stored in a variable called uport (seen as connect in other docs, should standardize this)
  - dev already understands what credentials are and wants to know how to attest them (correctness / understandability of "issue" vs "attest?")
- added section on "requesting the user to sign a credential"
  - link to "working with JWTs" guide (how to format link?)
- added section on "relaying an existing credential"
  - link to "server-side credentials tutorial" (how to format link?)
- changed "calling the attest method" section to "signing a credential about the user in app"
  - explain why client app can't hold signing key

Suggestions for future work

- merge this with the "request credentials" guide under a general "credentials" guide that explains their significance and how to perform various actions related to them
