### PR TITLE
Update request credentials guide

### DIFF
--- a/markdown/docs/guides/RequestCredentials.md
+++ b/markdown/docs/guides/RequestCredentials.md
@@ -8,36 +8,7 @@ source: "https://github.com/uport-project/uport-project.github.io/blob/develop/m
 
 # Requesting Credentials
 
-The first and most basic step you should take is to allow your user to connect their uPort to your app. Uport-connect's `requestCredentials` method is how you accomplish this, similar in concept to logging in , except there is no server session for you to manage. All you need to do to "connect" is to disclose the requested credentials you have in your uPort identity.
-
-![small-diag](diag1a.svg)
-
-### Desktop web
-
-<div class="overview-list" markdown=1>
-
-1. Browser displays QR code with URI
-1. Browser starts polling Chasqui using the sessionId to check if Mobile has posted the address & any other info required by the 3rd party app.
-1. Mobile scans QR code, displays card asking the user to share their address (and, optionally, other relevant data)
-1. If user consents: Mobile grabs sessionId from URI, posts address & data to the Chasqui API using the sessionId
-1. Browser grabs the address & data from Chasqui, removes QR code from UI
-
-</div>
-
-![small-diag](diag1b.svg)
-
-### Mobile web
-
-<div class="overview-list" markdown=1>
-
-1. Browser opens URL from the QR
-1. An alert is shown to the user asking if they want to open in the uPort app
-1. If user agrees, uPort app opens and displays card asking the user to share their address or other data (e.g., push token, attestation)
-1. If user agrees, uPort app creates a JWT that includes the requested data and signs it with the device key.
-1. Mobile browser is opened and an access_token field is appended to the URL. The access_token field contains the signed JWT.
-1. Mobile browser grabs the access_token JWT from the URL and extracts the iss (issuer) field which contains the uPort identity (address) & other requested data
-
-</div>
+Credentials are cryptographically signed messages containing information about a subject identity. They can be used by a decentralized system to authenticate users and enable interactions with data they control. uPort connect provides convenient functions that allow your application to request credentials from a user's uPort mobile app and handle the response.
 
 ## Calling the request method
 

--- a/markdown/docs/guides/RequestCredentials.md
+++ b/markdown/docs/guides/RequestCredentials.md
@@ -8,18 +8,18 @@ source: "https://github.com/uport-project/uport-project.github.io/blob/develop/m
 
 # Requesting Credentials
 
-Credentials are cryptographically signed messages containing information about a subject identity. They can be used by a decentralized system to authenticate users and enable interactions with data they control. uPort connect provides convenient functions that allow your application to request credentials from a user's uPort mobile app and handle the response.
+Credentials are cryptographically signed messages containing information about a subject identity. They can be used by a decentralized system to authenticate users and enable interactions with data they control. uPort connect provides convenient functions that allow your app to request credentials from a user's uPort mobile app and handle the response.
 
 ## Authenticating a user
 
-A user can be authenticated by issuing a request for their identity calling the `requestDisclosure` method of a `uport-connect` instance. By default, this request will be displayed as a link that attempts to open the uPort app if your application is accessed through a mobile client. On non-mobile clients, the request will be displayed as a QR code that can be scanned by a uPort mobile app. To learn more about how messages are passed between your app and a uPort client, check out [uport-transports](https://github.com/uport-project/uport-transports)
+A user can be authenticated by issuing a request for their identity calling the `requestDisclosure` method of a `uport-connect` instance. By default, this request will be displayed as a link that attempts to open the uPort app if your app is accessed through a mobile client. On non-mobile clients, the request will be displayed as a QR code that can be scanned by a uPort mobile app. To learn more about how messages are passed between your app and a uPort client, check out [uport-transports](https://github.com/uport-project/uport-transports)
 
 ```js
 // calling with no args requests the user's identity by default
 uport.requestDisclosure()
 ```
 
-Once the user approves the disclosure, their identity can be received as a promise returned by calling `onResponse`. It comes in the form of a [did](https://w3c-ccg.github.io/did-spec/#decentralized-identifiers-dids) that can be found in the `res.did` attribute of the response payload. `uport-connect` guarentees that the user your app is communicating with controls the identifier that they disclosed. To learn more about this process, check out our guide on [verifying JWTs](TODO: FIND LINK FOR THIS)
+Once the user approves the disclosure, their identity can be received as a promise returned by calling `onResponse`. It comes in the form of a [did](https://w3c-ccg.github.io/did-spec/#decentralized-identifiers-dids) that can be found in the `res.did` attribute of the response payload. `uport-connect` guarentees that the user your app is communicating with controls the identifier that they disclosed. To learn more about this process, check out our documentation on [verifying JWTs](/did-jwt/guides/index.md#verifying-a-jwt)
 
 ```js
 uport.onResponse('disclosureReq').then(payload => {
@@ -37,7 +37,7 @@ uport.onResponse('disclosureReq').then(payload => {
 
 ## Requesting specific credentials
 
-You can request specific credentials by submitting an array of values in an array of the `requested` key of a passed object. 
+You can request specific credentials by submitting an array of values in an array of the `requested` key of a passed object.
 
 ```js
 uport.requestDisclosure({
@@ -66,15 +66,14 @@ uport.onResponse('disclosureReq').then(payload => {
 })
 ```
 
-## Enabling Push Notifications
+## Enabling push notifications
 
-When a transaction is going to be signed, if the `notifications` flag is set to `true` **it will allow any future transaction signing to fire a prompt in the uPort mobile app.** For UX considerations, we encourage developers to use this, otherwise your users will have to scan a QR code per each interaction.
+Passing the option `notifications: true` will request the ability and permission for your app to make future requests to the user's uPort mobile app directly via push notifications. We encourage developers to use this for a more frictionless UX for non-mobile users of their app. For more information on push notifications work, check out our push notification service: [pututu](https://github.com/uport-project/lambda-pututu)
 
 ```js
-uport.requestCredentials({
-  requested: ['name', 'avatar', 'phone', 'country'],
-  notifications: true
-  }).then((userProfile) => {
-    // Do something after they have disclosed credentials
+uport.requestDisclosure({ notifications: true })
+
+uport.onResponse('disclosureReq').then(payload => {
+  // future requests will automatically be sent via push instead of QR for non-mobile app clients
 })
 ```

--- a/markdown/docs/guides/RequestCredentials.md
+++ b/markdown/docs/guides/RequestCredentials.md
@@ -10,38 +10,29 @@ source: "https://github.com/uport-project/uport-project.github.io/blob/develop/m
 
 Credentials are cryptographically signed messages containing information about a subject identity. They can be used by a decentralized system to authenticate users and enable interactions with data they control. uPort connect provides convenient functions that allow your application to request credentials from a user's uPort mobile app and handle the response.
 
-## Calling the request method
+## Authenticating a user
 
-**By default** the `uport-connect` library will fire a QR image inside of an injected global modal to help you get up and running quickly.
-
-**This can be disabled** by intercepting the URI so you may use another library to customize the look and feel of the QR image.
-
-Once the user has scanned the displayed QR image, and has submitted their credentials, the promise should resolve with a Schema.org person JSON data payload. You can then handle this data however you desire in the then function.
+A user can be authenticated by issuing a request for their identity calling the `requestDisclosure` method of a `uport-connect` instance. By default, this request will be displayed as a link that attempts to open the uPort app if your application is accessed through a mobile client. On non-mobile clients, the request will be displayed as a QR code that can be scanned by a uPort mobile app. To learn more about how messages are passed between your app and a uPort client, check out [uport-transports](https://github.com/uport-project/uport-transports)
 
 ```js
-// Basic usage with modal injection
-uport.requestCredentials()
-     .then((userProfile) => {
-       // Do something after they have disclosed credentials
-})
+// calling with no args requests the user's identity by default
+uport.requestDisclosure()
 ```
 
-The expected payload should look like:
+Once the user approves the disclosure, their identity can be received as a promise returned by calling `onResponse`. It comes in the form of a [did](https://w3c-ccg.github.io/did-spec/#decentralized-identifiers-dids) that can be found in the `res.did` attribute of the response payload. `uport-connect` guarentees that the user your app is communicating with controls the identifier that they disclosed. To learn more about this process, check out our guide on [verifying JWTs](TODO: FIND LINK FOR THIS)
 
 ```js
-{
-  "@context":"http://schema.org",
-  "@type":"Person",
-  "name":"Agent Smith",
-  "address":"23fga3r2hh87ddhq98dhas8dz101j9f449w0",
-  "avatar": {
-    "uri": "https://ipfs.infura.io/ipfs/QmaqGAeHmwAi44T6ZrSuu3yxwiyHPxoE1rHGmKxeCuZbS7DBX"
-  },
-  "country": "US"
-  "network":"rinkeby",
-  "publicEncKey": "dgH1devHn5MhAcph+np8MI4ZLB2kJWqRc4NTwtAj6Fs="
-  "publicKey":"0x04016751595cf2f1429367d6c83a826526g613b4f7574af55ded0364f0fb34600bceba9211e5864ae616d7e83b5e3c79f1c913b40c8d38c64952fef383fd3ad637",
-}
+uport.onResponse('disclosureReq').then(payload => {
+  console.log(payload)
+  // {
+  //   "data": undefined
+  //   "id": "disclosureReq",
+  //   "res": {
+  //     "boxPub": undefined,
+  //     "did": "did:uport:23fga3r2hh87ddhq98dhas8dz101j9f449w0",
+  //   }
+  // }
+})
 ```
 
 ## Requesting specific credentials

--- a/markdown/docs/guides/RequestCredentials.md
+++ b/markdown/docs/guides/RequestCredentials.md
@@ -66,23 +66,6 @@ uport.onResponse('disclosureReq').then(payload => {
 })
 ```
 
-## Verifying credentials
-
-To verify the signature on a credential you have received, pass the JWT given in the response to the uPort JS `credentials.receive()` function, which will look up the user's public key in the [uPort Registry](https://developer.uport.me/pki/index) and confirm it matches the credential's signature.
-
-```js
-const JWT = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1Z....'
-
-credentials.receive(jwt).then((creds) => {
-  if (creds.address == creds.verified[0].sub)
-  {
-    console.log('Credential verified.');
-  } else {
-    console.log('Verification failed.');
-  }
-})
- ```
-
 ## Enabling Push Notifications
 
 When a transaction is going to be signed, if the `notifications` flag is set to `true` **it will allow any future transaction signing to fire a prompt in the uPort mobile app.** For UX considerations, we encourage developers to use this, otherwise your users will have to scan a QR code per each interaction.

--- a/markdown/docs/guides/RequestCredentials.md
+++ b/markdown/docs/guides/RequestCredentials.md
@@ -37,13 +37,32 @@ uport.onResponse('disclosureReq').then(payload => {
 
 ## Requesting specific credentials
 
-You can request specific credentials by submitting an array of values in an array of the `requested` key of a passed object.
+You can request specific credentials by submitting an array of values in an array of the `requested` key of a passed object. 
 
 ```js
-uport.requestCredentials({
-  requested: ['name', 'avatar', 'phone', 'country'],
-  }).then((userProfile) => {
-    // Do something after they have disclosed credentials
+uport.requestDisclosure({
+    requested: ['name', 'avatar', 'phone', 'country'],
+})
+```
+
+This allows your app to use data about the user without having to store or control it. However, this means that your app also has to make some judgement about the veracity of that data. The only information that is guaranteed at this point is that the data has not been modified, and was created by the issuer identity about the user.
+
+```js
+uport.onResponse('disclosureReq').then(payload => {
+  console.log(payload)
+  // {
+  //   "data": undefined
+  //   "id": "disclosureReq",
+  //   "res": {
+  //     "avatar": "https://ipfs.infura.io/ipfs/QmaqGAeHmwAi44T6ZrSuu3yxwiyHPxoE1rHGmKxeCuZbS7DBX",
+  //     "name": "Agent Smith",
+  //     "phone": "+1-231-452-3857",
+  //     "country": "US",
+  //     "boxPub": "dgH1devHn5MhAcph+np8MI4ZLB2kJWqRc4NTwtAj6Fs=",
+  //     "publicEncKey": "dgH1devHn5MhAcph+np8MI4ZLB2kJWqRc4NTwtAj6Fs=",
+  //     "did": "did:uport:23fga3r2hh87ddhq98dhas8dz101j9f449w0",
+  //   }
+  // }
 })
 ```
 


### PR DESCRIPTION
Reasoning for changes

- updated the code blocks to use the correct syntax for major release version of uport-connect
- tried to reduce the information to the minimum necessary for a dev to write and understand code to request credentials from a uPort client
- assumptions
  - dev already has an instance of uport-connect stored in a variable called uport (seen as connect in other docs, should standardize this)
  - dev does not know the definition of credentials
- removed the diagrams because they contain more detail about the infrastructure than is necessary in this guide
- tried to make the intro more informative by answering what credentials are in this context, and why they are needed
- changed "calling the request method" to "authenticating a user" (would "requesting identity" be better?)
- link to transports (github for now, a guide would be better later)
- link to JWTs (need suggestion for best place to link)
- explain that app has to make judgement about veracity of data in a credential
- explain the need to judge requested credentials
- link to pututu (should this be another link to transports or some guide or reference about push instead?)

Suggestions for future work

- standardize the default variable name of a uport-connect instance in the docs (uport or connect?)
- it is likely that a dev coming to this page will not fully understand what a credential is in this context, or why it's needed
  - define it here (did this briefly in the intro)
  - link to a page in /reference
  - show definition in a tooltip on hover
  - describe in the "Getting Started" guide, assume they will read that first
- change uport-transports github page link to a transports guide link (once that guide exists)