### PR TITLE
doc: copy changes to RequestCredentials and SignTransactions

### DIFF
--- a/markdown/docs/guides/RequestCredentials.md
+++ b/markdown/docs/guides/RequestCredentials.md
@@ -8,11 +8,13 @@ source: "https://github.com/uport-project/uport-project.github.io/blob/develop/m
 
 # Requesting Credentials
 
-Credentials are cryptographically signed messages containing information about a subject identity. They can be used by a decentralized system to authenticate users and enable interactions with data they control. uPort connect provides convenient functions that allow your app to request credentials from a user's uPort mobile app and handle the response.
+Credentials are cryptographically signed messages containing information about a subject identity. They can be used by a decentralized system to authenticate users and enable interactions with data they control. uPort Connect provides convenient functions that allow your app to request credentials from a user's uPort mobile app and handle the response.
 
 ## Authenticating a user
 
 A user can be authenticated by issuing a request for their identity calling the `requestDisclosure` method of a `uport-connect` instance. By default, this request will be displayed as a link that attempts to open the uPort app if your app is accessed through a mobile client. On non-mobile clients, the request will be displayed as a QR code that can be scanned by a uPort mobile app. To learn more about how messages are passed between your app and a uPort client, check out [uport-transports](https://github.com/uport-project/uport-transports)
+
+Additionally, to help manage the multiple requests and responses that your flow may require, each request requires a string identifier, which is then used to fetch the proper response.  Each type of request has its own default id, which can be changed by passing a string as the second argument to the request.  For more details, see the uport-connect [reference](/uport-connect/reference/index.md).
 
 ```js
 // calling with no args requests the user's identity by default
@@ -22,6 +24,7 @@ uport.requestDisclosure()
 Once the user approves the disclosure, their identity can be received as a promise returned by calling `onResponse`. It comes in the form of a [did](https://w3c-ccg.github.io/did-spec/#decentralized-identifiers-dids) that can be found in the `res.did` attribute of the response payload. `uport-connect` guarentees that the user your app is communicating with controls the identifier that they disclosed. To learn more about this process, check out our documentation on [verifying JWTs](/did-jwt/guides/index.md#verifying-a-jwt)
 
 ```js
+// Note that the default id for `requestDisclosure` is 'disclosureReq'
 uport.onResponse('disclosureReq').then(payload => {
   console.log(payload)
   // {
@@ -45,7 +48,7 @@ uport.requestDisclosure({
 })
 ```
 
-This allows your app to use data about the user without having to store or control it. However, this means that your app also has to make some judgement about the veracity of that data. The only information that is guaranteed at this point is that the data has not been modified, and was created by the issuer identity about the user.
+This allows your app to use data about the user without having to store or control it, while still being able to verify its integrity.  It's important to note that this type of verification can provide guarantees only that the data originated from a particular identity, and that it hasn't been modified since then.  This cryptographic verification cannot provide any guarantees about the _validity_ or _truth_ of the data, or that the issuing identity is controlled by a particular person or entity in the real world, and it is up to your application to do that sort of higher level verification as necessary for your particular use case.
 
 ```js
 uport.onResponse('disclosureReq').then(payload => {

--- a/markdown/docs/guides/SignTransactions.md
+++ b/markdown/docs/guides/SignTransactions.md
@@ -12,18 +12,18 @@ source: "https://github.com/uport-project/uport-project.github.io/blob/develop/m
 
 ## uPort Requests
 
-Get the address of a uPort Id:
+Get the address of a uPort Id, simply use the standard `requestDislcosure` method with no arguments:
 
 ```javascript
-connect.requestAddress()
+connect.requestDisclosure()
 
-connect.onResponse('addressReq').then(payload => {
+connect.onResponse('disclosureReq').then(payload => {
   const address = connect.address
   const did = connect.did
 })
 ```
 
-To create a transaction request `contract()` or `sendTransaction()` can be used. `sendTransaction` consumes any valid transaction object, creates a uPort transaction request from it, and uses an appropriate transport (as described in examples above). The response is a transaction hash.
+To create a transaction request either the `contract()` or `sendTransaction()` methods can be used. `sendTransaction` consumes any valid transaction object, creates a uPort transaction request from it, and uses an appropriate transport (as described in examples above). The response is a transaction hash.
 
 ```javascript
 const txObj = {
@@ -31,12 +31,12 @@ const txObj = {
   value: 1 * 1.0e18
 }
 connect.sendTransaction(txObj, 'ethSendReq')
-connect.onResponse('ethSendReq').then(payload => {
-  const txId = payload.res
+connect.onResponse('ethSendReq').then(res => {
+  const txId = res.payload
 })
 ```
 
-Additionally you can create transaction requests with an interface similar to the familiar contract object in web3 (web3.eth.contract). Once given an ABI and address `connect.contract(abi).at(address)`, you can call the contract functions with this object. Keep in mind thought functionality is limited to function calls which require sending a transaction, as these are the only calls which require interaction with a uPort client. For reading and/or events use web3 along or a similar library along with `uport-connect`.
+Additionally you can create transaction requests with an interface similar to the familiar contract object in web3 (web3.eth.contract). Once given an ABI and address `connect.contract(abi).at(address)`, you can call the contract functions with this object. Keep in mind thought functionality is limited to function calls which require sending a transaction, as these are the only calls which require interaction with a uPort client. For reading and/or events use web3 along or a similar library along with `uport-connect`. _Also note that `Connect.contract` conforms to the *old* web3 contract API, which has changed in web3 v1.0.  This new API does not work entirely with uport's requirement that requests and responses are handled in separate function calls, so our contract is based on the older specification._
 
 Using this object over the provider examples below gives you more flexibility and control over the uPort request and response handling flows, where as the provider is more restrictive. It also gives you better access to uPort specific features.
 
@@ -92,3 +92,5 @@ The following calls will initiate a uPort request, by default this will show a Q
 * `web3.eth.getAccounts()`- returns your uport address in a list, if not set already
 * `web3.eth.sendTransaction(txObj)` - returns a transaction hash
 * `myContract.myMethod()` - returns a transaction hash
+
+While this may be the most convenient approach, it's important to note that because the web3 transaction handling is stateful, it requires that uPort requests and responses are handled on the same page. This means that for some mobile browsers, using a web3 object with a uport subprovider to send transactions may not work properly. Instead, for full mobile support we recommend using `Connect.sendTransaction`, or creating contracts via `Connect.contract`, and listening for responses from the mobile app with `Connect.onResponse`.


### PR DESCRIPTION
As discussed in other PR.  Some clarifications and expansion on web3 compatibility, removal of `requestAddress` function, limitations of verification, and info on request/response IDs.